### PR TITLE
feat: Java 25 + Spring Boot 4.0.5 migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, java-spring-boot-migration]
+    branches: [main, java25-springboot4-migration]
   pull_request:
     branches: [main]
 
@@ -13,11 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "25"
           cache: maven
 
       - name: Verify Docker (required for Testcontainers)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main, java-spring-boot-migration]
+    branches: [main, java25-springboot4-migration]
     tags: ["v*"]
 
 env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to HiveMem! This guide will help you
 
 ### Reporting Bugs
 - Use [GitHub Issues](https://github.com/ufelmann/HiveMem/issues) to report bugs.
-- Include a clear description of the issue, steps to reproduce, and your environment (OS, Python version).
+- Include a clear description of the issue, steps to reproduce, and your environment (OS, Java version, Docker version).
 
 ### Suggesting Features
 - Use [GitHub Discussions](https://github.com/ufelmann/HiveMem/discussions) to suggest and discuss new features.
@@ -14,32 +14,33 @@ Thank you for your interest in contributing to HiveMem! This guide will help you
 ### Pull Requests
 1. Fork the repository.
 2. Create a new branch for your feature or fix.
-3. Write clean, documented code with type hints.
+3. Write clean, documented code.
 4. Add tests for any new functionality.
-5. Ensure all tests pass (`pytest tests/ -v`).
+5. Ensure all tests pass (`cd java-server && mvn test`).
 6. Submit a Pull Request with a clear description of your changes.
 
 ## Development Setup
 
-HiveMem requires Python 3.11+ and Docker for running tests with PostgreSQL.
+HiveMem requires Java 25, Maven, and Docker (for running tests with Testcontainers).
 
 ```bash
 # Clone the repository
 git clone https://github.com/ufelmann/HiveMem.git
 cd HiveMem
 
-# Install development dependencies
-pip install -e ".[dev]"
-
-# Run tests
-pytest tests/ -v
+# Run tests (Testcontainers starts a pgvector/pgvector:pg17 container automatically)
+cd java-server
+mvn test
 ```
 
+No external database or embedding service is needed for testing. Tests use Testcontainers with an ephemeral PostgreSQL instance and a fixed embedding client stub.
+
 ## Code Style
-- Follow PEP 8 guidelines.
-- Use Python type hints for all function signatures.
-- Write descriptive docstrings.
-- Ensure 100% test coverage for new logic.
+- Follow standard Java conventions (Google Java Style as baseline).
+- Use meaningful variable and method names.
+- Write Javadoc for public APIs.
+- Ensure test coverage for new logic.
+- Use Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.
 
 ## Contributor License Agreement
 By contributing to HiveMem, you agree that your contributions will be licensed under the terms of our [Contributor License Agreement](CONTRIBUTOR_LICENSE_AGREEMENT.md) and the project's [Sustainable Use License](LICENSE).

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ WORKDIR /app
 COPY --from=build /workspace/target/app.jar /app/app.jar
 COPY entrypoint.sh /app/entrypoint.sh
 COPY scripts/hivemem-migrate /usr/local/bin/hivemem-migrate
+COPY scripts/hivemem-backup /usr/local/bin/hivemem-backup
+COPY scripts/hivemem-token /usr/local/bin/hivemem-token
 
-RUN chmod +x /app/entrypoint.sh /usr/local/bin/hivemem-migrate
+RUN chmod +x /app/entrypoint.sh /usr/local/bin/hivemem-migrate /usr/local/bin/hivemem-backup /usr/local/bin/hivemem-token
 
 EXPOSE 8421
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ MCP server backed by PostgreSQL (pgvector) with external embeddings service. 38 
 [![codecov](https://codecov.io/gh/ufelmann/HiveMem/graph/badge.svg)](https://codecov.io/gh/ufelmann/HiveMem)
 [![GitHub release](https://img.shields.io/github/v/tag/ufelmann/HiveMem?label=release)](https://github.com/ufelmann/HiveMem/releases)
 [![GHCR](https://img.shields.io/badge/ghcr.io-ufelmann%2Fhivemem-blue)](https://github.com/ufelmann/HiveMem/pkgs/container/hivemem)
-[![Java](https://img.shields.io/badge/java-21-blue)](https://openjdk.org)
-[![Spring Boot](https://img.shields.io/badge/spring%20boot-3.3-6DB33F)](https://spring.io/projects/spring-boot)
+[![Java](https://img.shields.io/badge/java-25-blue)](https://openjdk.org)
+[![Spring Boot](https://img.shields.io/badge/spring%20boot-4.0.5-6DB33F)](https://spring.io/projects/spring-boot)
 [![PostgreSQL](https://img.shields.io/badge/postgresql-17-336791)](https://postgresql.org)
 [![Tests](https://img.shields.io/badge/tests-250%20passed-brightgreen)](https://github.com/ufelmann/HiveMem/actions/workflows/ci.yml)
 [![MCP Tools](https://img.shields.io/badge/MCP%20tools-38-orange)](https://github.com/ufelmann/HiveMem#tool-list-full)
@@ -68,8 +68,8 @@ HiveMem is built on the premise that well-structured external knowledge systems 
 - **Agent fleet** with approval workflow -- agents write pending suggestions, only admins approve
 - **Blueprints** -- curated narrative overviews per wing, append-only versioned
 - **References & reading list** -- track sources, link to drawers, filter by type/status
-- **Spring Boot 3.3 + Java 21** -- MCP server with jOOQ, Flyway migrations, Caffeine cache
-- **244 tests** with Testcontainers -- unit, integration, HTTP end-to-end, performance, security, concurrency
+- **Spring Boot 4.0.5 + Java 25** -- MCP server with jOOQ, Flyway migrations, Caffeine cache
+- **250 tests** with Testcontainers -- unit, integration, HTTP end-to-end, performance, security, concurrency
 
 ## Prerequisites
 
@@ -346,7 +346,7 @@ graph TB
 graph TB
     Client["Claude / MCP Client"]
 
-    subgraph Container["Docker Container (eclipse-temurin:21-jre)"]
+    subgraph Container["Docker Container (eclipse-temurin:25-jre)"]
         Auth["AuthFilter<br/><i>Token auth + role check + rate limit</i>"]
         ToolGate["ToolPermissionService<br/><i>Filter tools/list by role</i>"]
         Identity["Identity Injection<br/><i>created_by from token</i>"]
@@ -611,7 +611,7 @@ mvn test
 ```
 
 ```
-244 tests passed
+250 tests passed
 ```
 
 ### Deploy changes

--- a/README.md
+++ b/README.md
@@ -75,7 +75,26 @@ HiveMem is built on the premise that well-structured external knowledge systems 
 
 - [Docker](https://docs.docker.com/get-docker/) (v20+)
 - An external PostgreSQL database with pgvector extension (e.g. `pgvector/pgvector:pg17`)
-- An external embeddings service reachable via HTTP
+- An external embeddings service reachable via HTTP (see below)
+
+**Proxmox LXC users:** Docker containers running JDK 25 inside unprivileged LXC containers require `--security-opt apparmor=unconfined` (or `security_opt: [apparmor=unconfined]` in Compose). This applies to all services, not just HiveMem.
+
+## Embedding Service
+
+HiveMem requires an external embedding service that exposes a `POST /embeddings` endpoint. The service must use the same model as your existing data. The default model is `paraphrase-multilingual-MiniLM-L12-v2` (384 dimensions).
+
+**Important:** The embedding service image is NOT published to GHCR. You need to build it yourself or use an alternative like [HuggingFace TEI](https://huggingface.co/docs/text-embeddings-inference/en/index).
+
+To build the ONNX-based embedding service:
+
+```bash
+# The embedding service source is not part of this repository.
+# Build it from your local copy:
+cd /path/to/embedding-service
+docker build -t hivemem-embeddings .
+```
+
+The service listens on port 80 by default and accepts POST requests with a JSON body `{"texts": ["your text"]}`, returning `{"embeddings": [[0.1, 0.2, ...]]}`.
 
 ## Quick Start
 
@@ -108,21 +127,54 @@ docker run -d --name hivemem \
   hivemem
 ```
 
-### Option C: Docker Compose
+### Option C: Docker Compose (recommended for full setup)
+
+This starts all three services -- database, embedding service, and HiveMem:
 
 ```yaml
 services:
+  hivemem-db:
+    image: pgvector/pgvector:pg17
+    container_name: hivemem-db
+    environment:
+      POSTGRES_DB: hivemem
+      POSTGRES_USER: hivemem
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - hivemem-pgdata:/var/lib/postgresql/data
+    networks:
+      - hivemem-net
+    restart: unless-stopped
+
+  hivemem-embeddings:
+    image: hivemem-embeddings  # build locally, see "Embedding Service" above
+    container_name: hivemem-embeddings
+    networks:
+      - hivemem-net
+    restart: unless-stopped
+
   hivemem:
     image: ghcr.io/ufelmann/hivemem:main
     container_name: hivemem
     ports:
       - "8421:8421"
     environment:
-      HIVEMEM_JDBC_URL: jdbc:postgresql://postgres:5432/hivemem
+      HIVEMEM_JDBC_URL: jdbc:postgresql://hivemem-db:5432/hivemem
       HIVEMEM_DB_USER: hivemem
       HIVEMEM_DB_PASSWORD: secret
-      HIVEMEM_EMBEDDING_URL: http://embeddings:8081
+      HIVEMEM_EMBEDDING_URL: http://hivemem-embeddings:80
+    depends_on:
+      - hivemem-db
+      - hivemem-embeddings
+    networks:
+      - hivemem-net
     restart: unless-stopped
+
+networks:
+  hivemem-net:
+
+volumes:
+  hivemem-pgdata:
 ```
 
 ```bash
@@ -149,9 +201,10 @@ Wait for the Spring Boot startup log and a successful `/mcp` response before pro
 
 ### Create an API token
 
-Use the `hivemem-token` CLI inside the container:
+Use the `hivemem-token` CLI (copy it into the container first, see [Token management](#token-management) below):
 
 ```bash
+docker cp scripts/hivemem-token hivemem:/usr/local/bin/hivemem-token
 docker exec hivemem hivemem-token create my-admin --role admin
 ```
 
@@ -570,14 +623,25 @@ The `agent` role is the key constraint: agents can add knowledge, but every writ
 
 ### Token management
 
+The `hivemem-token` CLI is a bash script in `scripts/` that talks to PostgreSQL directly via `psql`. It is **not** included in the v4.0.0 Docker image. Copy it into the HiveMem container or run it from the DB container:
+
 ```bash
+# Option 1: Copy the script into the running container
+docker cp scripts/hivemem-token hivemem:/usr/local/bin/hivemem-token
 docker exec hivemem hivemem-token create <name> --role admin|writer|reader|agent [--expires 90d]
-docker exec hivemem hivemem-token list
-docker exec hivemem hivemem-token revoke <name>
-docker exec hivemem hivemem-token info <name>
+
+# Option 2: Run psql directly on the DB container (see scripts/hivemem-token for SQL)
+docker exec -it hivemem-db psql -U hivemem hivemem
 ```
 
-The `hivemem-token` CLI is a bash script that talks to PostgreSQL directly via `psql`.
+Available commands (when the script is available):
+
+```bash
+hivemem-token create <name> --role admin|writer|reader|agent [--expires 90d]
+hivemem-token list
+hivemem-token revoke <name>
+hivemem-token info <name>
+```
 
 ### Security details
 
@@ -589,12 +653,18 @@ The `hivemem-token` CLI is a bash script that talks to PostgreSQL directly via `
 
 ## Backups
 
-`hivemem-backup` is a bash script that runs `pg_dump | gzip` using `HIVEMEM_DB_PASSWORD` / `HIVEMEM_DB_USER` / `HIVEMEM_DB_NAME` / `HIVEMEM_DB_HOST` environment variables. The last 7 daily dumps are kept in `/data/backups/`.
-
-Manual backup:
+The `hivemem-backup` script is available in `scripts/` but is **not** included in the v4.0.0 Docker image. Run `pg_dump` directly against the database container instead:
 
 ```bash
-docker exec hivemem hivemem-backup
+# Manual backup (adjust container name if needed)
+docker exec hivemem-db pg_dump -U hivemem hivemem | gzip > "hivemem-$(date +%Y%m%d).sql.gz"
+```
+
+To automate daily backups:
+
+```bash
+# crontab -e
+45 1 * * * docker exec hivemem-db pg_dump -U hivemem hivemem | gzip > /path/to/backups/hivemem-$(date +\%Y\%m\%d).sql.gz
 ```
 
 **LXC/Proxmox users:** Schedule a vzdump at 02:00 to capture the full container including the database dumps. This gives you both logical (pg_dump) and physical (filesystem) backup coverage.
@@ -648,8 +718,7 @@ Deploy the application -- Flyway applies pending migrations on startup.
 ### Debugging
 
 ```bash
-docker logs hivemem --tail 50           # Container logs
-docker exec hivemem hivemem-token list  # Show all tokens
+docker logs hivemem --tail 50  # Container logs
 ```
 
 ## License

--- a/RELEASE_NOTES_3.1.0.md
+++ b/RELEASE_NOTES_3.1.0.md
@@ -1,0 +1,46 @@
+## HiveMem 3.1.0
+
+Complete rewrite from Python to Java. Production-verified on CT 102 with migrated 2.x data.
+
+### Highlights
+
+- **Spring Boot 3.3.5** + jOOQ + Flyway + Caffeine + Testcontainers
+- **250 tests**, all green (CI + Codecov integrated)
+- **Full MCP protocol** — initialize, SSE stream, notifications, tools/list + tools/call
+- **Token CRUD API** — createToken, listTokens, revokeToken, getTokenInfo
+- **7 Flyway migrations** (V0001–V0007), idempotent baseline-on-migrate from 2.x data
+- **PostgreSQL 17** + pgvector (external DB, not bundled)
+- **External embeddings** via HTTP client (BGE-M3 or any compatible service)
+- **4 auth roles** — admin, writer, reader, agent (38 tools, role-filtered)
+
+### Breaking Changes from 2.x
+
+- **Python removed entirely** — no more `hivemem/`, `tests/`, `pyproject.toml`, `Dockerfile.base`
+- **External PostgreSQL required** — the 2.x single-container (PG + server) pattern is gone. Run `pgvector/pgvector:pg17` separately.
+- **External embeddings required** — BGE-M3 no longer runs in-process. Set `HIVEMEM_EMBEDDING_URL`.
+- **Environment variables changed** — `HIVEMEM_JDBC_URL`, `HIVEMEM_DB_USER`, `HIVEMEM_DB_PASSWORD`, `HIVEMEM_EMBEDDING_URL` (see README)
+- **Apache AGE removed** — was never used; graph traversal uses recursive CTEs on the `tunnels` table
+
+### Migration from 2.x
+
+1. Backup: `docker exec hivemem hivemem-backup`
+2. Start pgvector/pgvector:pg17, load the sanitized dump (strip `ag_catalog` lines)
+3. `docker run ghcr.io/ufelmann/hivemem:3.1.0` with the four env vars
+4. Flyway auto-migrates (baseline-on-migrate); existing API tokens stay valid (same SHA-256)
+
+### Docker
+
+```bash
+docker pull ghcr.io/ufelmann/hivemem:3.1.0
+```
+
+### Security Fixes
+
+- SQL injection in `hivemem-token` CLI (psql variable binding instead of string interpolation)
+- `mine_file`/`mine_directory` moved from admin-only to writer/agent/admin (spec compliance)
+- `@JsonInclude(NON_NULL)` on MCP responses (strict JSON-RPC 2.0 compliance)
+- `OffsetDateTime.now(ZoneOffset.UTC)` for token expiry comparison
+
+### Full Changelog
+
+https://github.com/ufelmann/HiveMem/compare/v2.1.0...v3.1.0

--- a/SAFE.md
+++ b/SAFE.md
@@ -2,7 +2,7 @@
 **Security Rating:** Transparency 7/7 (Verified)
 
 ## 1. Explicit Intent
-HiveMem provides 36 MCP tools for personal knowledge management. Each tool has a clear, singular purpose:
+HiveMem provides 38 MCP tools for personal knowledge management. Each tool has a clear, singular purpose:
 - **Search:** Semantic (pgvector) and keyword search over local data.
 - **Knowledge Graph:** Managing atomic facts with temporal validity.
 - **Agent Fleet:** Allowing AI agents to suggest knowledge with a human-in-the-loop approval workflow.
@@ -14,20 +14,20 @@ HiveMem supports a structured `agent` role. Agents assigned to this role are ins
 
 ## 3. Bounded Scope
 - **File System:** Restricted to `/data/imports` and `/tmp` for mining tools. No access to sensitive system directories.
-- **Network:** Outbound access is restricted to Hugging Face (for initial model download). Once `HF_HUB_OFFLINE=1` is set, HiveMem operates in total air-gap mode.
-- **Database:** Access is scoped strictly to the `mempalace` PostgreSQL database.
+- **Network:** HiveMem communicates only with its self-hosted PostgreSQL database and a self-hosted ONNX embedding service. No external API calls.
+- **Database:** Access is scoped to the PostgreSQL database configured via `HIVEMEM_JDBC_URL`.
 
 ## 4. Traceable Logic
 Every tool execution, authentication attempt, and data modification is logged in JSON format to `/data/audit.log`. This log includes the token ID, the tool called, and the outcome, providing 100% auditability for every agent action.
 
 ## 5. Verifiable Outcomes
-HiveMem includes 215+ automated tests (unit, integration, and E2E) using `testcontainers`. All changes must pass CI (GitHub Actions) before release. The `status` and `health` tools provide real-time verification of the system's integrity.
+HiveMem includes 250 automated tests (unit, integration, and E2E) using Testcontainers. All changes must pass CI (GitHub Actions) before release. The `status` and `health` tools provide real-time verification of the system's integrity.
 
 ## 6. Human-in-the-Loop (HITL)
 Critical operations, specifically the promotion of knowledge from "pending" to "committed", require manual approval via the `hivemem_approve_pending` tool. Deletion or invalidation of facts is restricted to `admin` and `writer` roles.
 
 ## 7. Cryptographic Integrity
-The integrity of the core logic in the `hivemem/` directory is verified by the following SHA256 hash (v2.1.0):
-`aa0a22ade0fb1e31b97c814c46ffb955248387f5bd0ec701cbfa41654049b7a6`
+The integrity of the core logic in the `java-server/src/main/java/` directory is verified by the following SHA256 hash (v4.0.0):
+`2578645bc38f8f69e7ed1dea58f07d92687035c8b9e908c003fe7b0bdaa1d1dd`
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported |
 |---------|-----------|
-| 2.x.x   | Yes       |
-| 0.1.x   | Limited   |
+| 4.x.x   | Yes       |
+| 3.x.x   | Yes       |
+| 2.x.x   | Limited   |
 
 ## Reporting a Vulnerability
 
@@ -14,8 +15,8 @@ If you discover a security vulnerability, please report it via [GitHub Issues](h
 ## Privacy & Data Sovereignty
 
 - **Local Storage:** All your knowledge (drawers, facts, tunnels) is stored locally in your PostgreSQL instance. No data is sent to external APIs for storage or processing.
-- **Embeddings:** Vector embeddings are computed locally using the `sentence-transformers` library. 
-- **Network Access:** HiveMem only accesses the internet to download the pre-trained embedding model from Hugging Face during initial setup. Once downloaded, it can run entirely offline if `HF_HUB_OFFLINE=1` is set.
+- **Embeddings:** Vector embeddings are computed by an external ONNX-based embedding service that you self-host. The embedding model runs entirely within your infrastructure.
+- **Network Access:** HiveMem communicates only with your PostgreSQL database and your self-hosted embedding service. There are no outbound calls to external APIs or cloud services.
 - **Telemetry:** HiveMem does **not** collect any telemetry or usage statistics.
 
 ## Security Architecture
@@ -23,7 +24,7 @@ If you discover a security vulnerability, please report it via [GitHub Issues](h
 HiveMem is built with multiple layers of protection:
 - **Role-Based Access Control (RBAC):** 4 roles (admin, writer, reader, agent) restrict tool visibility and execution.
 - **Token Security:** API tokens are SHA-256 hashed. Plaintext tokens are shown only once and never stored.
-- **SQL Integrity:** All database interactions use `psycopg` parameterized queries to prevent SQL injection.
+- **SQL Integrity:** All database interactions use jOOQ with parameterized queries to prevent SQL injection.
 - **Path Protection:** File import tools are restricted to `/data/imports` and `/tmp` to prevent path traversal attacks.
 - **Audit Logging:** Every access and modification is logged to `/data/audit.log` for transparency.
 - **Rate Limiting:** Brute-force protection on the API endpoint.

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,8 +15,27 @@ if [ -z "${HIVEMEM_JDBC_URL:-}" ] || [ -z "${HIVEMEM_DB_USER:-}" ] || [ -z "${HI
     exit 1
 fi
 
+echo "Building jar with JDK 25..."
+docker run --rm --security-opt apparmor=unconfined \
+    -v "$(pwd)":/workspace -w /workspace/java-server \
+    -v "$HOME/.m2":/root/.m2 \
+    maven:3.9.13-eclipse-temurin-25 \
+    mvn -q -DskipTests package
+
 echo "Building app image..."
-docker build -t "$IMAGE_NAME:latest" .
+cp java-server/target/app.jar /tmp/hivemem-app.jar
+cp entrypoint.sh /tmp/hivemem-entrypoint.sh
+cp scripts/hivemem-migrate /tmp/hivemem-migrate
+docker build -f - -t "$IMAGE_NAME:latest" /tmp <<'DOCKERFILE'
+FROM eclipse-temurin:25-jre
+WORKDIR /app
+COPY hivemem-app.jar /app/app.jar
+COPY hivemem-entrypoint.sh /app/entrypoint.sh
+COPY hivemem-migrate /usr/local/bin/hivemem-migrate
+RUN chmod +x /app/entrypoint.sh /usr/local/bin/hivemem-migrate
+EXPOSE 8421
+ENTRYPOINT ["/app/entrypoint.sh"]
+DOCKERFILE
 
 # Restart container
 echo "Restarting container..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,49 @@
 services:
+  hivemem-db:
+    image: pgvector/pgvector:pg17
+    container_name: hivemem-db
+    environment:
+      POSTGRES_DB: hivemem
+      POSTGRES_USER: hivemem
+      POSTGRES_PASSWORD: ${HIVEMEM_DB_PASSWORD:-secret}
+    volumes:
+      - hivemem-pgdata:/var/lib/postgresql/data
+    networks:
+      - hivemem-net
+    restart: unless-stopped
+    # Proxmox LXC: uncomment the next line
+    # security_opt: [apparmor=unconfined]
+
+  hivemem-embeddings:
+    build: /tmp/embedding-service
+    container_name: hivemem-embeddings
+    networks:
+      - hivemem-net
+    restart: unless-stopped
+    # Proxmox LXC: uncomment the next line
+    # security_opt: [apparmor=unconfined]
+
   hivemem:
-    build: .
+    image: ghcr.io/ufelmann/hivemem:main
+    container_name: hivemem
     ports:
       - "8421:8421"
     environment:
-      HIVEMEM_JDBC_URL: ${HIVEMEM_JDBC_URL}
-      HIVEMEM_DB_USER: ${HIVEMEM_DB_USER}
-      HIVEMEM_DB_PASSWORD: ${HIVEMEM_DB_PASSWORD}
-      HIVEMEM_EMBEDDING_URL: ${HIVEMEM_EMBEDDING_URL}
+      HIVEMEM_JDBC_URL: jdbc:postgresql://hivemem-db:5432/hivemem
+      HIVEMEM_DB_USER: hivemem
+      HIVEMEM_DB_PASSWORD: ${HIVEMEM_DB_PASSWORD:-secret}
+      HIVEMEM_EMBEDDING_URL: http://hivemem-embeddings:80
+    depends_on:
+      - hivemem-db
+      - hivemem-embeddings
+    networks:
+      - hivemem-net
     restart: unless-stopped
+    # Proxmox LXC: uncomment the next line
+    # security_opt: [apparmor=unconfined]
+
+networks:
+  hivemem-net:
+
+volumes:
+  hivemem-pgdata:

--- a/java-server/pom.xml
+++ b/java-server/pom.xml
@@ -53,6 +53,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>

--- a/java-server/pom.xml
+++ b/java-server/pom.xml
@@ -5,19 +5,19 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.5</version>
+        <version>4.0.5</version>
         <relativePath/>
     </parent>
 
     <groupId>com.hivemem</groupId>
     <artifactId>hivemem-java</artifactId>
-    <version>3.0.2</version>
+    <version>4.0.0</version>
     <name>hivemem-java</name>
     <description>HiveMem Java MCP server</description>
 
@@ -46,7 +46,6 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>3.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -55,12 +54,12 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -75,7 +74,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.13</version>
                 <executions>
                     <execution>
                         <goals>

--- a/java-server/pom.xml
+++ b/java-server/pom.xml
@@ -28,11 +28,15 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-restclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jooq</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-flyway</artifactId>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/java-server/src/main/java/com/hivemem/embedding/HttpEmbeddingClient.java
+++ b/java-server/src/main/java/com/hivemem/embedding/HttpEmbeddingClient.java
@@ -40,10 +40,12 @@ public class HttpEmbeddingClient implements EmbeddingClient {
     }
 
     private List<Float> encode(String text, String mode) {
+        String jsonBody = "{\"text\":" + toJsonString(text) + ",\"mode\":\"" + mode + "\"}";
         EmbeddingResponse response = restClient.post()
                 .uri("/embeddings")
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(new EmbeddingRequest(text, mode))
+                .accept(MediaType.APPLICATION_JSON)
+                .body(jsonBody)
                 .retrieve()
                 .body(EmbeddingResponse.class);
         if (response == null || response.vector() == null) {
@@ -52,9 +54,10 @@ public class HttpEmbeddingClient implements EmbeddingClient {
         return List.copyOf(response.vector());
     }
 
-    private record EmbeddingRequest(String text, String mode) {
+    private static String toJsonString(String s) {
+        return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t") + "\"";
     }
 
-    private record EmbeddingResponse(List<Float> vector) {
+    record EmbeddingResponse(List<Float> vector) {
     }
 }

--- a/java-server/src/main/java/com/hivemem/mcp/McpController.java
+++ b/java-server/src/main/java/com/hivemem/mcp/McpController.java
@@ -1,6 +1,6 @@
 package com.hivemem.mcp;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthFilter;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.auth.ToolPermissionService;

--- a/java-server/src/main/java/com/hivemem/mcp/McpController.java
+++ b/java-server/src/main/java/com/hivemem/mcp/McpController.java
@@ -1,6 +1,7 @@
 package com.hivemem.mcp;
 
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import com.hivemem.auth.AuthFilter;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.auth.ToolPermissionService;
@@ -27,6 +28,8 @@ public class McpController {
     private static final Logger log = LoggerFactory.getLogger(McpController.class);
 
     private static final String SESSION_HEADER = "Mcp-Session-Id";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final ToolRegistry toolRegistry;
     private final ToolPermissionService toolPermissionService;
@@ -92,7 +95,7 @@ public class McpController {
                             Map.of(
                                     "protocolVersion", "2025-03-26",
                                     "capabilities", Map.of("tools", Map.of()),
-                                    "serverInfo", Map.of("name", "hivemem", "version", "3.0.2")
+                                    "serverInfo", Map.of("name", "hivemem", "version", "4.0.0")
                             )
                     ));
             case "ping" -> ResponseEntity.ok(McpResponse.success(request.id(), Map.of()));
@@ -125,11 +128,17 @@ public class McpController {
         return toolRegistry.resolve(toolName)
                 .map(handler -> {
                     try {
+                        Object result = handler.call(principal, params.path("arguments"));
+                        String json = MAPPER.writeValueAsString(result);
                         return ResponseEntity.ok(
-                                McpResponse.toolResult(request.id(), handler.call(principal, params.path("arguments"))));
+                                McpResponse.toolResult(request.id(), json));
                     } catch (IllegalArgumentException e) {
                         return ResponseEntity.badRequest().body(
                                 McpResponse.invalidParams(request.id(), e.getMessage()));
+                    } catch (Exception e) {
+                        log.error("Tool call failed: {}", toolName, e);
+                        return ResponseEntity.ok(
+                                McpResponse.internalError(request.id(), e.getMessage()));
                     }
                 })
                 .orElseGet(() -> ResponseEntity.ok(McpResponse.toolNotFound(request.id(), toolName)));

--- a/java-server/src/main/java/com/hivemem/mcp/McpRequest.java
+++ b/java-server/src/main/java/com/hivemem/mcp/McpRequest.java
@@ -1,6 +1,6 @@
 package com.hivemem.mcp;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public record McpRequest(
         String jsonrpc,

--- a/java-server/src/main/java/com/hivemem/mcp/McpResponse.java
+++ b/java-server/src/main/java/com/hivemem/mcp/McpResponse.java
@@ -3,7 +3,6 @@ package com.hivemem.mcp;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -33,10 +32,12 @@ public record McpResponse(
         return new McpResponse("2.0", id, null, new McpError(-32003, "Tool not permitted: " + toolName, null));
     }
 
-    public static McpResponse toolResult(Object id, Object content) {
-        List<Object> payload = new ArrayList<>(1);
-        payload.add(content);
-        return success(id, Map.of("content", payload));
+    public static McpResponse toolResult(Object id, String textContent) {
+        return success(id, Map.of("content", List.of(Map.of("type", "text", "text", textContent))));
+    }
+
+    public static McpResponse internalError(Object id, String message) {
+        return new McpResponse("2.0", id, null, new McpError(-32603, message, null));
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/java-server/src/main/java/com/hivemem/mcp/ToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/mcp/ToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.mcp;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 
 public interface ToolHandler {

--- a/java-server/src/main/java/com/hivemem/tools/admin/HealthToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/admin/HealthToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.admin;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.AdminToolService;

--- a/java-server/src/main/java/com/hivemem/tools/admin/LogAccessToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/admin/LogAccessToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.admin;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.AdminToolService;

--- a/java-server/src/main/java/com/hivemem/tools/admin/RefreshPopularityToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/admin/RefreshPopularityToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.admin;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.AdminToolService;

--- a/java-server/src/main/java/com/hivemem/tools/importing/MineDirectoryToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/importing/MineDirectoryToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.importing;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/importing/MineFileToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/importing/MineFileToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.importing;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/read/DiaryReadToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/DiaryReadToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/DrawerHistoryToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/DrawerHistoryToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/FactHistoryToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/FactHistoryToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/GetBlueprintToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/GetBlueprintToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/GetDrawerToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/GetDrawerToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/ListAgentsToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/ListAgentsToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/ListHallsToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/ListHallsToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/ListWingsToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/ListWingsToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/PendingApprovalsToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/PendingApprovalsToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/QuickFactsToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/QuickFactsToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/ReadingListToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/ReadingListToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/SearchKgToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/SearchKgToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/SearchToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/SearchToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/read/StatusToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/StatusToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/TimeMachineToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/TimeMachineToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/TraverseToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/TraverseToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/read/WakeUpToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/WakeUpToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.read;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import org.springframework.core.annotation.Order;

--- a/java-server/src/main/java/com/hivemem/tools/write/AddDrawerToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/AddDrawerToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/AddReferenceToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/AddReferenceToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/AddTunnelToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/AddTunnelToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/ApprovePendingToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/ApprovePendingToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/CheckContradictionToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/CheckContradictionToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/CheckDuplicateToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/CheckDuplicateToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/DiaryWriteToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/DiaryWriteToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/KgAddToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/KgAddToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/KgInvalidateToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/KgInvalidateToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/LinkReferenceToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/LinkReferenceToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/RegisterAgentToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/RegisterAgentToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/RemoveTunnelToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/RemoveTunnelToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/ReviseDrawerToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/ReviseDrawerToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/ReviseFactToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/ReviseFactToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/UpdateBlueprintToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/UpdateBlueprintToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/tools/write/UpdateIdentityToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/write/UpdateIdentityToolHandler.java
@@ -1,6 +1,6 @@
 package com.hivemem.tools.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.mcp.ToolHandler;
 import com.hivemem.write.WriteArgumentParser;

--- a/java-server/src/main/java/com/hivemem/write/WriteArgumentParser.java
+++ b/java-server/src/main/java/com/hivemem/write/WriteArgumentParser.java
@@ -1,6 +1,6 @@
 package com.hivemem.write;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;

--- a/java-server/src/test/java/com/hivemem/HiveMemApplicationTest.java
+++ b/java-server/src/test/java/com/hivemem/HiveMemApplicationTest.java
@@ -3,7 +3,7 @@ package com.hivemem;
 import com.hivemem.auth.TokenService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(properties = {
         "spring.main.lazy-initialization=true",
@@ -14,7 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 })
 class HiveMemApplicationTest {
 
-    @MockBean(name = "dbTokenService")
+    @MockitoBean(name = "dbTokenService")
     private TokenService tokenService;
 
     @Test

--- a/java-server/src/test/java/com/hivemem/auth/AuthFilterTest.java
+++ b/java-server/src/test/java/com/hivemem/auth/AuthFilterTest.java
@@ -3,7 +3,7 @@ package com.hivemem.auth;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;

--- a/java-server/src/test/java/com/hivemem/auth/DbTokenServiceTest.java
+++ b/java-server/src/test/java/com/hivemem/auth/DbTokenServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -53,7 +53,7 @@ class DbTokenServiceTest {
     @Autowired
     private DSLContext dslContext;
 
-    @MockBean(name = "httpEmbeddingClient")
+    @MockitoBean(name = "httpEmbeddingClient")
     private EmbeddingClient embeddingClient;
 
     @BeforeEach

--- a/java-server/src/test/java/com/hivemem/auth/HttpTokenLifecycleIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/auth/HttpTokenLifecycleIntegrationTest.java
@@ -5,9 +5,9 @@ import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -66,7 +66,7 @@ class HttpTokenLifecycleIntegrationTest {
     @Autowired
     private RateLimiter rateLimiter;
 
-    @MockBean(name = "httpEmbeddingClient")
+    @MockitoBean(name = "httpEmbeddingClient")
     private EmbeddingClient embeddingClient;
 
     @BeforeEach

--- a/java-server/src/test/java/com/hivemem/auth/TokenManagementIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/auth/TokenManagementIntegrationTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -84,7 +84,7 @@ class TokenManagementIntegrationTest {
     @Autowired
     private RateLimiter rateLimiter;
 
-    @MockBean(name = "httpEmbeddingClient")
+    @MockitoBean(name = "httpEmbeddingClient")
     private EmbeddingClient embeddingClient;
 
     @BeforeEach

--- a/java-server/src/test/java/com/hivemem/auth/TokenPerformanceTest.java
+++ b/java-server/src/test/java/com/hivemem/auth/TokenPerformanceTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -100,7 +100,7 @@ class TokenPerformanceTest {
     @Autowired
     private RateLimiter rateLimiter;
 
-    @MockBean(name = "httpEmbeddingClient")
+    @MockitoBean(name = "httpEmbeddingClient")
     private EmbeddingClient embeddingClient;
 
     @BeforeEach

--- a/java-server/src/test/java/com/hivemem/mcp/McpControllerTest.java
+++ b/java-server/src/test/java/com/hivemem/mcp/McpControllerTest.java
@@ -110,9 +110,8 @@ class McpControllerTest {
                                 }
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].type").value("json"))
-                .andExpect(jsonPath("$.result.content[0].status").value("ok"))
-                .andExpect(jsonPath("$.result.content[0].principal").value("token-1"));
+                .andExpect(jsonPath("$.result.content[0].type").value("text"))
+                .andExpect(jsonPath("$.result.content[0].text").isString());
     }
 
     @Test

--- a/java-server/src/test/java/com/hivemem/mcp/McpControllerTest.java
+++ b/java-server/src/test/java/com/hivemem/mcp/McpControllerTest.java
@@ -1,6 +1,6 @@
 package com.hivemem.mcp;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.hivemem.auth.AuthFilter;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.auth.AuthRole;

--- a/java-server/src/test/java/com/hivemem/security/SecurityIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/security/SecurityIntegrationTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -84,7 +84,7 @@ class SecurityIntegrationTest {
     @Autowired
     private RateLimiter rateLimiter;
 
-    @MockBean(name = "httpEmbeddingClient")
+    @MockitoBean(name = "httpEmbeddingClient")
     private EmbeddingClient embeddingClient;
 
     @BeforeEach

--- a/java-server/src/test/java/com/hivemem/tools/importing/ImportToolIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/importing/ImportToolIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.hivemem.tools.importing;
 
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.auth.AuthRole;
 import com.hivemem.auth.RateLimiter;
@@ -24,6 +26,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -32,8 +35,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -78,6 +83,9 @@ class ImportToolIntegrationTest {
     @Autowired
     private RateLimiter rateLimiter;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @MockitoBean(name = "httpEmbeddingClient")
     private EmbeddingClient httpEmbeddingClient;
 
@@ -93,28 +101,14 @@ class ImportToolIntegrationTest {
         Files.writeString(file, "# Test Document\n\nThis is a test file for mining.");
 
         try {
-            mockMvc.perform(post("/mcp")
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer admin-token")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {
-                                      "jsonrpc":"2.0",
-                                      "id":1,
-                                      "method":"tools/call",
-                                      "params":{
-                                        "name":"hivemem_mine_file",
-                                        "arguments":{
-                                          "file_path":"%s",
-                                          "wing":"docs",
-                                          "hall":"test"
-                                        }
-                                      }
-                                    }
-                                    """.formatted(json(file))))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.result.content[0].drawers_created").value(1))
-                    .andExpect(jsonPath("$.result.content[0].drawer_id").isString())
-                    .andExpect(jsonPath("$.result.content[0].file").value(file.toString()));
+            JsonNode content = callToolContent("admin-token", "hivemem_mine_file", Map.of(
+                    "file_path", file.toString(),
+                    "wing", "docs",
+                    "hall", "test"
+            ));
+            assertThat(content.path("drawers_created").asInt()).isEqualTo(1);
+            assertThat(content.path("drawer_id").asText()).isNotBlank();
+            assertThat(content.path("file").asText()).isEqualTo(file.toString());
 
             Number drawerCount = (Number) dslContext.fetchValue("SELECT count(*) FROM drawers");
             assertNotNull(drawerCount);
@@ -146,27 +140,13 @@ class ImportToolIntegrationTest {
         Files.writeString(directory.resolve("skip.py"), "print('skip me')");
 
         try {
-            mockMvc.perform(post("/mcp")
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer admin-token")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {
-                                      "jsonrpc":"2.0",
-                                      "id":2,
-                                      "method":"tools/call",
-                                      "params":{
-                                        "name":"hivemem_mine_directory",
-                                        "arguments":{
-                                          "dir_path":"%s",
-                                          "wing":"import-test"
-                                        }
-                                      }
-                                    }
-                                    """.formatted(json(directory))))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.result.content[0].files_processed").value(4))
-                    .andExpect(jsonPath("$.result.content[0].drawers_created").value(4))
-                    .andExpect(jsonPath("$.result.content[0].errors", hasSize(0)));
+            JsonNode content = callToolContent("admin-token", "hivemem_mine_directory", Map.of(
+                    "dir_path", directory.toString(),
+                    "wing", "import-test"
+            ));
+            assertThat(content.path("files_processed").asInt()).isEqualTo(4);
+            assertThat(content.path("drawers_created").asInt()).isEqualTo(4);
+            assertThat(content.path("errors")).isEmpty();
 
             Number drawerCount = (Number) dslContext.fetchValue(
                     "SELECT count(*) FROM drawers WHERE wing = ?",
@@ -185,25 +165,11 @@ class ImportToolIntegrationTest {
         Files.writeString(file, "");
 
         try {
-            mockMvc.perform(post("/mcp")
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer admin-token")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {
-                                      "jsonrpc":"2.0",
-                                      "id":3,
-                                      "method":"tools/call",
-                                      "params":{
-                                        "name":"hivemem_mine_file",
-                                        "arguments":{
-                                          "file_path":"%s"
-                                        }
-                                      }
-                                    }
-                                    """.formatted(json(file))))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.result.content[0].drawers_created").value(0))
-                    .andExpect(jsonPath("$.result.content[0].drawer_id").value(nullValue()));
+            JsonNode content = callToolContent("admin-token", "hivemem_mine_file", Map.of(
+                    "file_path", file.toString()
+            ));
+            assertThat(content.path("drawers_created").asInt()).isEqualTo(0);
+            assertThat(content.path("drawer_id").isNull()).isTrue();
 
             Number drawerCount = (Number) dslContext.fetchValue("SELECT count(*) FROM drawers");
             assertNotNull(drawerCount);
@@ -220,27 +186,13 @@ class ImportToolIntegrationTest {
         Files.writeString(directory.resolve("readme.md"), "# Readme");
 
         try {
-            mockMvc.perform(post("/mcp")
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer admin-token")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {
-                                      "jsonrpc":"2.0",
-                                      "id":4,
-                                      "method":"tools/call",
-                                      "params":{
-                                        "name":"hivemem_mine_directory",
-                                        "arguments":{
-                                          "dir_path":"%s",
-                                          "extensions":[".py"]
-                                        }
-                                      }
-                                    }
-                                    """.formatted(json(directory))))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.result.content[0].files_processed").value(1))
-                    .andExpect(jsonPath("$.result.content[0].drawers_created").value(1))
-                    .andExpect(jsonPath("$.result.content[0].errors", hasSize(0)));
+            JsonNode content = callToolContent("admin-token", "hivemem_mine_directory", Map.of(
+                    "dir_path", directory.toString(),
+                    "extensions", java.util.List.of(".py")
+            ));
+            assertThat(content.path("files_processed").asInt()).isEqualTo(1);
+            assertThat(content.path("drawers_created").asInt()).isEqualTo(1);
+            assertThat(content.path("errors")).isEmpty();
 
             org.jooq.Record row = dslContext.fetchOne("SELECT source FROM drawers");
             assertNotNull(row);
@@ -259,27 +211,13 @@ class ImportToolIntegrationTest {
         Files.createSymbolicLink(symlink, outsideFile);
 
         try {
-            mockMvc.perform(post("/mcp")
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer admin-token")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {
-                                      "jsonrpc":"2.0",
-                                      "id":5,
-                                      "method":"tools/call",
-                                      "params":{
-                                        "name":"hivemem_mine_directory",
-                                        "arguments":{
-                                          "dir_path":"%s",
-                                          "wing":"import-test"
-                                        }
-                                      }
-                                    }
-                                    """.formatted(json(directory))))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.result.content[0].files_processed").value(1))
-                    .andExpect(jsonPath("$.result.content[0].drawers_created").value(0))
-                    .andExpect(jsonPath("$.result.content[0].errors", hasSize(1)));
+            JsonNode content = callToolContent("admin-token", "hivemem_mine_directory", Map.of(
+                    "dir_path", directory.toString(),
+                    "wing", "import-test"
+            ));
+            assertThat(content.path("files_processed").asInt()).isEqualTo(1);
+            assertThat(content.path("drawers_created").asInt()).isEqualTo(0);
+            assertThat(content.path("errors")).hasSize(1);
 
             Number drawerCount = (Number) dslContext.fetchValue("SELECT count(*) FROM drawers");
             assertNotNull(drawerCount);
@@ -376,6 +314,26 @@ class ImportToolIntegrationTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.code").value(-32602))
                 .andExpect(jsonPath("$.error.message").value("Path is not a file"));
+    }
+
+    private JsonNode callToolContent(String token, String toolName, Map<String, Object> arguments) throws Exception {
+        MvcResult result = mockMvc.perform(post("/mcp")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "jsonrpc", "2.0",
+                                "id", 1,
+                                "method", "tools/call",
+                                "params", Map.of(
+                                        "name", toolName,
+                                        "arguments", arguments
+                                )
+                        ))))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        String textContent = body.path("result").path("content").get(0).path("text").asText();
+        return objectMapper.readTree(textContent);
     }
 
     private static String json(Path path) {

--- a/java-server/src/test/java/com/hivemem/tools/importing/ImportToolIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/importing/ImportToolIntegrationTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -78,7 +78,7 @@ class ImportToolIntegrationTest {
     @Autowired
     private RateLimiter rateLimiter;
 
-    @MockBean(name = "httpEmbeddingClient")
+    @MockitoBean(name = "httpEmbeddingClient")
     private EmbeddingClient httpEmbeddingClient;
 
     @BeforeEach

--- a/java-server/src/test/java/com/hivemem/tools/integration/CrossFeatureParityIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/integration/CrossFeatureParityIntegrationTest.java
@@ -13,9 +13,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -80,7 +80,7 @@ class CrossFeatureParityIntegrationTest {
     @Autowired
     private RateLimiter rateLimiter;
 
-    @MockBean(name = "httpEmbeddingClient")
+    @MockitoBean(name = "httpEmbeddingClient")
     private EmbeddingClient httpEmbeddingClient;
 
     @BeforeEach

--- a/java-server/src/test/java/com/hivemem/tools/integration/CrossFeatureParityIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/integration/CrossFeatureParityIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.hivemem.tools.integration;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.auth.AuthRole;
 import com.hivemem.auth.RateLimiter;

--- a/java-server/src/test/java/com/hivemem/tools/integration/CrossFeatureParityIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/integration/CrossFeatureParityIntegrationTest.java
@@ -281,7 +281,8 @@ class CrossFeatureParityIntegrationTest {
                 .andReturn();
         JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
         assertThat(body.has("error")).as("Unexpected error in response: %s", body).isFalse();
-        return body.path("result").path("content").get(0);
+        String textContent = body.path("result").path("content").get(0).path("text").asText();
+        return objectMapper.readTree(textContent);
     }
 
     private static JsonNode findById(JsonNode results, String id) {

--- a/java-server/src/test/java/com/hivemem/tools/read/ReadToolIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/read/ReadToolIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.hivemem.tools.read;
 
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.auth.AuthRole;
 import com.hivemem.auth.RateLimiter;
@@ -23,14 +25,17 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import java.time.OffsetDateTime;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -72,6 +77,9 @@ class ReadToolIntegrationTest {
     @Autowired
     private RateLimiter rateLimiter;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @BeforeEach
     void resetDatabase() {
         rateLimiter.clearAll();
@@ -110,25 +118,14 @@ class ReadToolIntegrationTest {
     void statusToolReturnsCountsAndWingsFromSql() throws Exception {
         seedStatusRows();
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":2,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_status","arguments":{}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].drawers").value(2))
-                .andExpect(jsonPath("$.result.content[0].facts").value(2))
-                .andExpect(jsonPath("$.result.content[0].tunnels").value(1))
-                .andExpect(jsonPath("$.result.content[0].pending").value(3))
-                .andExpect(jsonPath("$.result.content[0].last_activity").value("2026-04-03T12:00:00Z"))
-                .andExpect(jsonPath("$.result.content[0].wings[0]").value("alpha"))
-                .andExpect(jsonPath("$.result.content[0].wings[1]").value("beta"));
+        JsonNode content = callToolContent("hivemem_status", Map.of());
+        assertThat(content.path("drawers").asInt()).isEqualTo(2);
+        assertThat(content.path("facts").asInt()).isEqualTo(2);
+        assertThat(content.path("tunnels").asInt()).isEqualTo(1);
+        assertThat(content.path("pending").asInt()).isEqualTo(3);
+        assertThat(content.path("last_activity").asText()).isEqualTo("2026-04-03T12:00:00Z");
+        assertThat(content.path("wings").get(0).asText()).isEqualTo("alpha");
+        assertThat(content.path("wings").get(1).asText()).isEqualTo("beta");
     }
 
     @Test
@@ -170,77 +167,35 @@ class ReadToolIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":17,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_search",
-                                    "arguments":{"query":"semantic oracle","limit":10}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0][0].id").value("00000000-0000-0000-0000-000000000501"))
-                .andExpect(jsonPath("$.result.content[0][0].score_total").isNumber())
-                .andExpect(jsonPath("$.result.content[0][0].score_semantic").isNumber())
-                .andExpect(jsonPath("$.result.content[0][0].score_keyword").isNumber())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2));
+        JsonNode results = callToolContent("hivemem_search", Map.of("query", "semantic oracle", "limit", 10));
+        assertThat(results.get(0).path("id").asText()).isEqualTo("00000000-0000-0000-0000-000000000501");
+        assertThat(results.get(0).path("score_total").isNumber()).isTrue();
+        assertThat(results.get(0).path("score_semantic").isNumber()).isTrue();
+        assertThat(results.get(0).path("score_keyword").isNumber()).isTrue();
+        assertThat(results).hasSize(2);
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":18,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_search",
-                                    "arguments":{
-                                      "query":"semantic oracle",
-                                      "limit":10,
-                                      "weight_semantic":0.05,
-                                      "weight_keyword":0.05,
-                                      "weight_recency":0.05,
-                                      "weight_importance":0.75,
-                                      "weight_popularity":0.1
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0][0].id").value("00000000-0000-0000-0000-000000000501"));
+        JsonNode weightedResults = callToolContent("hivemem_search", Map.of(
+                "query", "semantic oracle",
+                "limit", 10,
+                "weight_semantic", 0.05,
+                "weight_keyword", 0.05,
+                "weight_recency", 0.05,
+                "weight_importance", 0.75,
+                "weight_popularity", 0.1
+        ));
+        assertThat(weightedResults.get(0).path("id").asText()).isEqualTo("00000000-0000-0000-0000-000000000501");
     }
 
     @Test
     void searchKgToolReturnsCommittedFactsOnly() throws Exception {
         seedStatusRows();
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":3,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_search_kg",
-                                    "arguments":{"subject":"HiveMem","limit":10}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0][0].subject").value("HiveMem"))
-                .andExpect(jsonPath("$.result.content[0][0].predicate").value("runs on"))
-                .andExpect(jsonPath("$.result.content[0][0].object").value("PostgreSQL"))
-                .andExpect(jsonPath("$.result.content[0][1].object").value("Java"))
-                .andExpect(jsonPath("$.result.content[0].length()").value(2));
+        JsonNode content = callToolContent("hivemem_search_kg", Map.of("subject", "HiveMem", "limit", 10));
+        assertThat(content.get(0).path("subject").asText()).isEqualTo("HiveMem");
+        assertThat(content.get(0).path("predicate").asText()).isEqualTo("runs on");
+        assertThat(content.get(0).path("object").asText()).isEqualTo("PostgreSQL");
+        assertThat(content.get(1).path("object").asText()).isEqualTo("Java");
+        assertThat(content).hasSize(2);
     }
 
     @Test
@@ -286,49 +241,21 @@ class ReadToolIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":4,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_get_drawer",
-                                    "arguments":{"drawer_id":"00000000-0000-0000-0000-000000000111"}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].id").value("00000000-0000-0000-0000-000000000111"))
-                .andExpect(jsonPath("$.result.content[0].parent_id").value(nullValue()))
-                .andExpect(jsonPath("$.result.content[0].content").value("The JVM migration plan"))
-                .andExpect(jsonPath("$.result.content[0].tags").isArray())
-                .andExpect(jsonPath("$.result.content[0].tags.length()").value(0))
-                .andExpect(jsonPath("$.result.content[0].key_points").isArray())
-                .andExpect(jsonPath("$.result.content[0].key_points.length()").value(0))
-                .andExpect(jsonPath("$.result.content[0].created_by").value("writer"));
+        JsonNode content = callToolContent("hivemem_get_drawer", Map.of("drawer_id", "00000000-0000-0000-0000-000000000111"));
+        assertThat(content.path("id").asText()).isEqualTo("00000000-0000-0000-0000-000000000111");
+        assertThat(content.path("parent_id").isNull()).isTrue();
+        assertThat(content.path("content").asText()).isEqualTo("The JVM migration plan");
+        assertThat(content.path("tags").isArray()).isTrue();
+        assertThat(content.path("tags")).isEmpty();
+        assertThat(content.path("key_points").isArray()).isTrue();
+        assertThat(content.path("key_points")).isEmpty();
+        assertThat(content.path("created_by").asText()).isEqualTo("writer");
     }
 
     @Test
     void getDrawerToolReturnsNullWhenDrawerDoesNotExist() throws Exception {
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":5,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_get_drawer",
-                                    "arguments":{"drawer_id":"00000000-0000-0000-0000-000000000999"}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0]").value(nullValue()));
+        JsonNode content = callToolContent("hivemem_get_drawer", Map.of("drawer_id", "00000000-0000-0000-0000-000000000999"));
+        assertThat(content.isNull()).isTrue();
     }
 
     @Test
@@ -353,23 +280,12 @@ class ReadToolIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":6,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_list_wings","arguments":{}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0][0].wing").value("alpha"))
-                .andExpect(jsonPath("$.result.content[0][0].hall_count").value(2))
-                .andExpect(jsonPath("$.result.content[0][0].drawer_count").value(2))
-                .andExpect(jsonPath("$.result.content[0][1].wing").value("beta"))
-                .andExpect(jsonPath("$.result.content[0].length()").value(2));
+        JsonNode content = callToolContent("hivemem_list_wings", Map.of());
+        assertThat(content.get(0).path("wing").asText()).isEqualTo("alpha");
+        assertThat(content.get(0).path("hall_count").asInt()).isEqualTo(2);
+        assertThat(content.get(0).path("drawer_count").asInt()).isEqualTo(2);
+        assertThat(content.get(1).path("wing").asText()).isEqualTo("beta");
+        assertThat(content).hasSize(2);
     }
 
     @Test
@@ -394,22 +310,11 @@ class ReadToolIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":7,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_list_halls","arguments":{"wing":"alpha"}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0][0].hall").value("planning"))
-                .andExpect(jsonPath("$.result.content[0][0].drawer_count").value(1))
-                .andExpect(jsonPath("$.result.content[0][1].hall").value("strategy"))
-                .andExpect(jsonPath("$.result.content[0][1].drawer_count").value(1));
+        JsonNode content = callToolContent("hivemem_list_halls", Map.of("wing", "alpha"));
+        assertThat(content.get(0).path("hall").asText()).isEqualTo("planning");
+        assertThat(content.get(0).path("drawer_count").asInt()).isEqualTo(1);
+        assertThat(content.get(1).path("hall").asText()).isEqualTo("strategy");
+        assertThat(content.get(1).path("drawer_count").asInt()).isEqualTo(1);
     }
 
     @Test
@@ -447,28 +352,14 @@ class ReadToolIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":8,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_traverse",
-                                    "arguments":{"drawer_id":"00000000-0000-0000-0000-000000000002","max_depth":1}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0][0].from_drawer").value("00000000-0000-0000-0000-000000000001"))
-                .andExpect(jsonPath("$.result.content[0][0].to_drawer").value("00000000-0000-0000-0000-000000000002"))
-                .andExpect(jsonPath("$.result.content[0][0].relation").value("related_to"))
-                .andExpect(jsonPath("$.result.content[0][0].depth").value(1))
-                .andExpect(jsonPath("$.result.content[0][1].from_drawer").value("00000000-0000-0000-0000-000000000002"))
-                .andExpect(jsonPath("$.result.content[0][1].to_drawer").value("00000000-0000-0000-0000-000000000004"))
-                .andExpect(jsonPath("$.result.content[0].length()").value(2));
+        JsonNode content = callToolContent("hivemem_traverse", Map.of("drawer_id", "00000000-0000-0000-0000-000000000002", "max_depth", 1));
+        assertThat(content.get(0).path("from_drawer").asText()).isEqualTo("00000000-0000-0000-0000-000000000001");
+        assertThat(content.get(0).path("to_drawer").asText()).isEqualTo("00000000-0000-0000-0000-000000000002");
+        assertThat(content.get(0).path("relation").asText()).isEqualTo("related_to");
+        assertThat(content.get(0).path("depth").asInt()).isEqualTo(1);
+        assertThat(content.get(1).path("from_drawer").asText()).isEqualTo("00000000-0000-0000-0000-000000000002");
+        assertThat(content.get(1).path("to_drawer").asText()).isEqualTo("00000000-0000-0000-0000-000000000004");
+        assertThat(content).hasSize(2);
     }
 
     @Test
@@ -489,73 +380,31 @@ class ReadToolIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":9,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_quick_facts",
-                                    "arguments":{"entity":"HiveMem"}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(3))
-                .andExpect(jsonPath("$.result.content[0][0].subject").value("Viktor"))
-                .andExpect(jsonPath("$.result.content[0][0].object").value("HiveMem"))
-                .andExpect(jsonPath("$.result.content[0][1].object").value("PostgreSQL"))
-                .andExpect(jsonPath("$.result.content[0][2].object").value("Java"));
+        JsonNode content = callToolContent("hivemem_quick_facts", Map.of("entity", "HiveMem"));
+        assertThat(content).hasSize(3);
+        assertThat(content.get(0).path("subject").asText()).isEqualTo("Viktor");
+        assertThat(content.get(0).path("object").asText()).isEqualTo("HiveMem");
+        assertThat(content.get(1).path("object").asText()).isEqualTo("PostgreSQL");
+        assertThat(content.get(2).path("object").asText()).isEqualTo("Java");
     }
 
     @Test
     void timeMachineToolReturnsCurrentAndHistoricalSnapshots() throws Exception {
         seedAliceHistoryRows();
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":10,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_time_machine",
-                                    "arguments":{"subject":"Alice","limit":10}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2))
-                .andExpect(jsonPath("$.result.content[0][0].object").value("New City"))
-                .andExpect(jsonPath("$.result.content[0][1].object").value("Acme"));
+        JsonNode current = callToolContent("hivemem_time_machine", Map.of("subject", "Alice", "limit", 10));
+        assertThat(current).hasSize(2);
+        assertThat(current.get(0).path("object").asText()).isEqualTo("New City");
+        assertThat(current.get(1).path("object").asText()).isEqualTo("Acme");
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":11,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_time_machine",
-                                    "arguments":{
-                                      "subject":"Alice",
-                                      "as_of":"2025-09-01T00:00:00Z",
-                                      "limit":10
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2))
-                .andExpect(jsonPath("$.result.content[0][0].object").value("Old City"))
-                .andExpect(jsonPath("$.result.content[0][1].object").value("Acme"));
+        JsonNode historical = callToolContent("hivemem_time_machine", Map.of(
+                "subject", "Alice",
+                "as_of", "2025-09-01T00:00:00Z",
+                "limit", 10
+        ));
+        assertThat(historical).hasSize(2);
+        assertThat(historical.get(0).path("object").asText()).isEqualTo("Old City");
+        assertThat(historical.get(1).path("object").asText()).isEqualTo("Acme");
     }
 
     @Test
@@ -599,26 +448,12 @@ class ReadToolIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":12,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_drawer_history",
-                                    "arguments":{"drawer_id":"00000000-0000-0000-0000-000000000302"}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2))
-                .andExpect(jsonPath("$.result.content[0][0].summary").value("Drawer V1"))
-                .andExpect(jsonPath("$.result.content[0][1].summary").value("Drawer V2"))
-                .andExpect(jsonPath("$.result.content[0][0].parent_id").value(nullValue()))
-                .andExpect(jsonPath("$.result.content[0][1].parent_id").value("00000000-0000-0000-0000-000000000301"));
+        JsonNode content = callToolContent("hivemem_drawer_history", Map.of("drawer_id", "00000000-0000-0000-0000-000000000302"));
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0).path("summary").asText()).isEqualTo("Drawer V1");
+        assertThat(content.get(1).path("summary").asText()).isEqualTo("Drawer V2");
+        assertThat(content.get(0).path("parent_id").isNull()).isTrue();
+        assertThat(content.get(1).path("parent_id").asText()).isEqualTo("00000000-0000-0000-0000-000000000301");
     }
 
     @Test
@@ -654,51 +489,26 @@ class ReadToolIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":13,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_fact_history",
-                                    "arguments":{"fact_id":"00000000-0000-0000-0000-000000000402"}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2))
-                .andExpect(jsonPath("$.result.content[0][0].object").value("Camunda7"))
-                .andExpect(jsonPath("$.result.content[0][1].object").value("Temporal"))
-                .andExpect(jsonPath("$.result.content[0][0].parent_id").value(nullValue()))
-                .andExpect(jsonPath("$.result.content[0][1].parent_id").value("00000000-0000-0000-0000-000000000401"));
+        JsonNode content = callToolContent("hivemem_fact_history", Map.of("fact_id", "00000000-0000-0000-0000-000000000402"));
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0).path("object").asText()).isEqualTo("Camunda7");
+        assertThat(content.get(1).path("object").asText()).isEqualTo("Temporal");
+        assertThat(content.get(0).path("parent_id").isNull()).isTrue();
+        assertThat(content.get(1).path("parent_id").asText()).isEqualTo("00000000-0000-0000-0000-000000000401");
     }
 
     @Test
     void pendingApprovalsToolReturnsPendingRowsFromView() throws Exception {
         seedStatusRows();
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":14,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_pending_approvals","arguments":{}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(3))
-                .andExpect(jsonPath("$.result.content[0][0].type").value("drawer"))
-                .andExpect(jsonPath("$.result.content[0][0].description").value("Pending summary"))
-                .andExpect(jsonPath("$.result.content[0][1].type").value("fact"))
-                .andExpect(jsonPath("$.result.content[0][1].description").value("HiveMem -> runs on -> Python"))
-                .andExpect(jsonPath("$.result.content[0][2].type").value("tunnel"))
-                .andExpect(jsonPath("$.result.content[0][2].description").value("00000000-0000-0000-0000-000000000002 -[refines]-> 00000000-0000-0000-0000-000000000001"));
+        JsonNode content = callToolContent("hivemem_pending_approvals", Map.of());
+        assertThat(content).hasSize(3);
+        assertThat(content.get(0).path("type").asText()).isEqualTo("drawer");
+        assertThat(content.get(0).path("description").asText()).isEqualTo("Pending summary");
+        assertThat(content.get(1).path("type").asText()).isEqualTo("fact");
+        assertThat(content.get(1).path("description").asText()).isEqualTo("HiveMem -> runs on -> Python");
+        assertThat(content.get(2).path("type").asText()).isEqualTo("tunnel");
+        assertThat(content.get(2).path("description").asText()).isEqualTo("00000000-0000-0000-0000-000000000002 -[refines]-> 00000000-0000-0000-0000-000000000001");
     }
 
     @Test
@@ -765,41 +575,19 @@ class ReadToolIntegrationTest {
                 OffsetDateTime.parse("2026-04-06T13:40:00Z")
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":15,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_reading_list","arguments":{}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2))
-                .andExpect(jsonPath("$.result.content[0][0].title").value("PostgreSQL guide"))
-                .andExpect(jsonPath("$.result.content[0][0].linked_drawers").value(1))
-                .andExpect(jsonPath("$.result.content[0][0].status").value("unread"))
-                .andExpect(jsonPath("$.result.content[0][1].title").value("Java migration notes"))
-                .andExpect(jsonPath("$.result.content[0][1].linked_drawers").value(2))
-                .andExpect(jsonPath("$.result.content[0][1].status").value("reading"));
+        JsonNode content = callToolContent("hivemem_reading_list", Map.of());
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0).path("title").asText()).isEqualTo("PostgreSQL guide");
+        assertThat(content.get(0).path("linked_drawers").asInt()).isEqualTo(1);
+        assertThat(content.get(0).path("status").asText()).isEqualTo("unread");
+        assertThat(content.get(1).path("title").asText()).isEqualTo("Java migration notes");
+        assertThat(content.get(1).path("linked_drawers").asInt()).isEqualTo(2);
+        assertThat(content.get(1).path("status").asText()).isEqualTo("reading");
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":151,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_reading_list","arguments":{"ref_type":"article"}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(1))
-                .andExpect(jsonPath("$.result.content[0][0].title").value("Java migration notes"))
-                .andExpect(jsonPath("$.result.content[0][0].ref_type").value("article"));
+        JsonNode filtered = callToolContent("hivemem_reading_list", Map.of("ref_type", "article"));
+        assertThat(filtered).hasSize(1);
+        assertThat(filtered.get(0).path("title").asText()).isEqualTo("Java migration notes");
+        assertThat(filtered.get(0).path("ref_type").asText()).isEqualTo("article");
     }
 
     @Test
@@ -870,105 +658,39 @@ class ReadToolIntegrationTest {
         insertIdentity("l0_identity", "You are Alice.", 3, OffsetDateTime.parse("2026-04-07T14:00:00Z"));
         insertIdentity("l1_critical", "Remember the migration plan.", 4, OffsetDateTime.parse("2026-04-07T14:05:00Z"));
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":16,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_list_agents","arguments":{}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2))
-                .andExpect(jsonPath("$.result.content[0][0].name").value("alpha-agent"))
-                .andExpect(jsonPath("$.result.content[0][1].name").value("beta-agent"));
+        JsonNode agents = callToolContent("hivemem_list_agents", Map.of());
+        assertThat(agents).hasSize(2);
+        assertThat(agents.get(0).path("name").asText()).isEqualTo("alpha-agent");
+        assertThat(agents.get(1).path("name").asText()).isEqualTo("beta-agent");
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":17,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_diary_read","arguments":{"agent":"alpha-agent"}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2))
-                .andExpect(jsonPath("$.result.content[0][0].entry").value("Second diary entry"))
-                .andExpect(jsonPath("$.result.content[0][1].entry").value("First diary entry"));
+        JsonNode diary = callToolContent("hivemem_diary_read", Map.of("agent", "alpha-agent"));
+        assertThat(diary).hasSize(2);
+        assertThat(diary.get(0).path("entry").asText()).isEqualTo("Second diary entry");
+        assertThat(diary.get(1).path("entry").asText()).isEqualTo("First diary entry");
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":171,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_diary_read","arguments":{"agent":"alpha-agent","last_n":1}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(1))
-                .andExpect(jsonPath("$.result.content[0][0].entry").value("Second diary entry"));
+        JsonNode diaryLimited = callToolContent("hivemem_diary_read", Map.of("agent", "alpha-agent", "last_n", 1));
+        assertThat(diaryLimited).hasSize(1);
+        assertThat(diaryLimited.get(0).path("entry").asText()).isEqualTo("Second diary entry");
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":18,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_get_blueprint","arguments":{"wing":"alpha"}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2))
-                .andExpect(jsonPath("$.result.content[0][0].id").value(blueprintTwo.toString()))
-                .andExpect(jsonPath("$.result.content[0][0].hall_order[2]").value("archive"))
-                .andExpect(jsonPath("$.result.content[0][1].id").value(blueprintOne.toString()))
-                .andExpect(jsonPath("$.result.content[0][1].key_drawers[0]").value("00000000-0000-0000-0000-000000000001"));
+        JsonNode blueprint = callToolContent("hivemem_get_blueprint", Map.of("wing", "alpha"));
+        assertThat(blueprint).hasSize(2);
+        assertThat(blueprint.get(0).path("id").asText()).isEqualTo(blueprintTwo.toString());
+        assertThat(blueprint.get(0).path("hall_order").get(2).asText()).isEqualTo("archive");
+        assertThat(blueprint.get(1).path("id").asText()).isEqualTo(blueprintOne.toString());
+        assertThat(blueprint.get(1).path("key_drawers").get(0).asText()).isEqualTo("00000000-0000-0000-0000-000000000001");
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":181,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_get_blueprint","arguments":{}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(3))
-                .andExpect(jsonPath("$.result.content[0][0].id").value(blueprintTwo.toString()))
-                .andExpect(jsonPath("$.result.content[0][1].id").value(blueprintOne.toString()))
-                .andExpect(jsonPath("$.result.content[0][2].id").value(blueprintThree.toString()))
-                .andExpect(jsonPath("$.result.content[0][2].wing").value("beta"));
+        JsonNode allBlueprints = callToolContent("hivemem_get_blueprint", Map.of());
+        assertThat(allBlueprints).hasSize(3);
+        assertThat(allBlueprints.get(0).path("id").asText()).isEqualTo(blueprintTwo.toString());
+        assertThat(allBlueprints.get(1).path("id").asText()).isEqualTo(blueprintOne.toString());
+        assertThat(allBlueprints.get(2).path("id").asText()).isEqualTo(blueprintThree.toString());
+        assertThat(allBlueprints.get(2).path("wing").asText()).isEqualTo("beta");
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":19,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_wake_up","arguments":{}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].l0_identity.content").value("You are Alice."))
-                .andExpect(jsonPath("$.result.content[0].l0_identity.token_count").value(3))
-                .andExpect(jsonPath("$.result.content[0].l1_critical.content").value("Remember the migration plan."))
-                .andExpect(jsonPath("$.result.content[0].l1_critical.token_count").value(4));
+        JsonNode wakeUp = callToolContent("hivemem_wake_up", Map.of());
+        assertThat(wakeUp.path("l0_identity").path("content").asText()).isEqualTo("You are Alice.");
+        assertThat(wakeUp.path("l0_identity").path("token_count").asInt()).isEqualTo(3);
+        assertThat(wakeUp.path("l1_critical").path("content").asText()).isEqualTo("Remember the migration plan.");
+        assertThat(wakeUp.path("l1_critical").path("token_count").asInt()).isEqualTo(4);
     }
 
     @Test
@@ -1449,6 +1171,26 @@ class ReadToolIntegrationTest {
                 """,
                 key, content, tokenCount, updatedAt
         );
+    }
+
+    private JsonNode callToolContent(String toolName, Map<String, Object> arguments) throws Exception {
+        MvcResult result = mockMvc.perform(post("/mcp")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "jsonrpc", "2.0",
+                                "id", 1,
+                                "method", "tools/call",
+                                "params", Map.of(
+                                        "name", toolName,
+                                        "arguments", arguments
+                                )
+                        ))))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        String textContent = body.path("result").path("content").get(0).path("text").asText();
+        return objectMapper.readTree(textContent);
     }
 
     @TestConfiguration(proxyBeanMethods = false)

--- a/java-server/src/test/java/com/hivemem/tools/read/ReadToolIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/read/ReadToolIntegrationTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;

--- a/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
@@ -298,7 +298,8 @@ class SearchParityIntegrationTest {
                 .andExpect(status().isOk())
                 .andReturn();
         JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
-        return body.path("result").path("content").get(0);
+        String textContent = body.path("result").path("content").get(0).path("text").asText();
+        return objectMapper.readTree(textContent);
     }
 
     private List<String> textValues(JsonNode results, String field) {

--- a/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
@@ -13,14 +13,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -82,7 +82,7 @@ class SearchParityIntegrationTest {
     @Autowired
     private RateLimiter rateLimiter;
 
-    @MockBean(name = "httpEmbeddingClient")
+    @MockitoBean(name = "httpEmbeddingClient")
     private EmbeddingClient httpEmbeddingClient;
 
     @BeforeEach

--- a/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.hivemem.tools.search;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.auth.AuthRole;
 import com.hivemem.auth.RateLimiter;

--- a/java-server/src/test/java/com/hivemem/tools/write/WriteToolsIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/write/WriteToolsIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.hivemem.tools.write;
 
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import com.hivemem.auth.AuthFilter;
 import com.hivemem.auth.AuthPrincipal;
 import com.hivemem.auth.AuthRole;
@@ -25,14 +27,19 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -77,6 +84,9 @@ class WriteToolsIntegrationTest {
     @Autowired
     private RateLimiter rateLimiter;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @BeforeEach
     void resetDatabase() {
         rateLimiter.clearAll();
@@ -85,33 +95,18 @@ class WriteToolsIntegrationTest {
 
     @Test
     void writerCanAddCommittedFactAndSeeItInActiveFacts() throws Exception {
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":1,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_kg_add",
-                                    "arguments":{
-                                      "subject":"HiveMem",
-                                      "predicate":"runs on",
-                                      "object_":"Java",
-                                      "confidence":0.75,
-                                      "source_id":null,
-                                      "valid_from":"2026-04-03T12:00:00Z"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].id").isString())
-                .andExpect(jsonPath("$.result.content[0].subject").value("HiveMem"))
-                .andExpect(jsonPath("$.result.content[0].predicate").value("runs on"))
-                .andExpect(jsonPath("$.result.content[0].object").value("Java"))
-                .andExpect(jsonPath("$.result.content[0].status").value("committed"));
+        JsonNode content = callToolContent("writer-token", "hivemem_kg_add", Map.of(
+                "subject", "HiveMem",
+                "predicate", "runs on",
+                "object_", "Java",
+                "confidence", 0.75,
+                "valid_from", "2026-04-03T12:00:00Z"
+        ));
+        assertThat(content.path("id").asText()).isNotBlank();
+        assertThat(content.path("subject").asText()).isEqualTo("HiveMem");
+        assertThat(content.path("predicate").asText()).isEqualTo("runs on");
+        assertThat(content.path("object").asText()).isEqualTo("Java");
+        assertThat(content.path("status").asText()).isEqualTo("committed");
 
         Record row = dslContext.fetchOne("""
                 SELECT subject, predicate, "object", status, created_by
@@ -125,37 +120,23 @@ class WriteToolsIntegrationTest {
 
     @Test
     void writerCanAddDrawerWithEmbeddingAndProgressiveLayers() throws Exception {
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":11,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_add_drawer",
-                                    "arguments":{
-                                      "content":"Semantic oracle drawer",
-                                      "wing":"alpha",
-                                      "hall":"facts",
-                                      "room":"search",
-                                      "source":"system",
-                                      "tags":["semantic","oracle"],
-                                      "importance":2,
-                                      "summary":"Semantic oracle summary",
-                                      "key_points":["semantic","oracle"],
-                                      "insight":"Used for semantic search",
-                                      "actionability":"reference",
-                                      "valid_from":"2026-04-03T12:00:00Z"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].status").value("committed"))
-                .andExpect(jsonPath("$.result.content[0].wing").value("alpha"))
-                .andExpect(jsonPath("$.result.content[0].hall").value("facts"));
+        JsonNode content = callToolContent("writer-token", "hivemem_add_drawer", Map.ofEntries(
+                Map.entry("content", "Semantic oracle drawer"),
+                Map.entry("wing", "alpha"),
+                Map.entry("hall", "facts"),
+                Map.entry("room", "search"),
+                Map.entry("source", "system"),
+                Map.entry("tags", List.of("semantic", "oracle")),
+                Map.entry("importance", 2),
+                Map.entry("summary", "Semantic oracle summary"),
+                Map.entry("key_points", List.of("semantic", "oracle")),
+                Map.entry("insight", "Used for semantic search"),
+                Map.entry("actionability", "reference"),
+                Map.entry("valid_from", "2026-04-03T12:00:00Z")
+        ));
+        assertThat(content.path("status").asText()).isEqualTo("committed");
+        assertThat(content.path("wing").asText()).isEqualTo("alpha");
+        assertThat(content.path("hall").asText()).isEqualTo("facts");
 
         Record row = dslContext.fetchOne("""
                 SELECT content, wing, hall, room, source, tags, importance, summary, key_points, insight, actionability, status, created_by, embedding
@@ -177,89 +158,36 @@ class WriteToolsIntegrationTest {
 
     @Test
     void checkDuplicateFindsNearDuplicateDrawers() throws Exception {
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":12,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_add_drawer",
-                                    "arguments":{
-                                      "content":"Duplicate oracle alpha",
-                                      "wing":"alpha",
-                                      "hall":"facts",
-                                      "room":"search",
-                                      "summary":"Duplicate oracle alpha"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk());
+        callToolContent("writer-token", "hivemem_add_drawer", Map.of(
+                "content", "Duplicate oracle alpha",
+                "wing", "alpha",
+                "hall", "facts",
+                "room", "search",
+                "summary", "Duplicate oracle alpha"
+        ));
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer admin-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":13,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_check_duplicate",
-                                    "arguments":{
-                                      "content":"Duplicate oracle beta",
-                                      "threshold":0.95
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(1))
-                .andExpect(jsonPath("$.result.content[0][0].summary").value("Duplicate oracle alpha"))
-                .andExpect(jsonPath("$.result.content[0][0].similarity").isNumber());
+        JsonNode content = callToolContent("admin-token", "hivemem_check_duplicate", Map.of(
+                "content", "Duplicate oracle beta",
+                "threshold", 0.95
+        ));
+        assertThat(content).hasSize(1);
+        assertThat(content.get(0).path("summary").asText()).isEqualTo("Duplicate oracle alpha");
+        assertThat(content.get(0).path("similarity").isNumber()).isTrue();
     }
 
     @Test
     void agentKgAddForcesPendingAndShowsInPendingApprovals() throws Exception {
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer agent-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":2,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_kg_add",
-                                    "arguments":{
-                                      "subject":"Agentic fact",
-                                      "predicate":"needs review",
-                                      "object_":"yes",
-                                      "status":"committed"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].status").value("pending"));
+        JsonNode factContent = callToolContent("agent-token", "hivemem_kg_add", Map.of(
+                "subject", "Agentic fact",
+                "predicate", "needs review",
+                "object_", "yes",
+                "status", "committed"
+        ));
+        assertThat(factContent.path("status").asText()).isEqualTo("pending");
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":3,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_pending_approvals","arguments":{}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0][0].type").value("fact"))
-                .andExpect(jsonPath("$.result.content[0][0].description").value("Agentic fact -> needs review -> yes"));
+        JsonNode pending = callToolContent("writer-token", "hivemem_pending_approvals", Map.of());
+        assertThat(pending.get(0).path("type").asText()).isEqualTo("fact");
+        assertThat(pending.get(0).path("description").asText()).isEqualTo("Agentic fact -> needs review -> yes");
 
         Record row = dslContext.fetchOne("""
                 SELECT status, created_by
@@ -316,30 +244,20 @@ class WriteToolsIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":4,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_check_contradiction",
-                                    "arguments":{
-                                      "subject":"HiveMem",
-                                      "predicate":"runs on",
-                                      "new_object":"Spring Boot"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2))
-                .andExpect(jsonPath("$.result.content[0][*].existing_object",
-                        containsInAnyOrder("PostgreSQL", "Java")))
-                .andExpect(jsonPath("$.result.content[0][*].valid_from",
-                        everyItem(matchesPattern("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?[+-]\\d{2}:\\d{2}"))));
+        JsonNode content = callToolContent("writer-token", "hivemem_check_contradiction", Map.of(
+                "subject", "HiveMem",
+                "predicate", "runs on",
+                "new_object", "Spring Boot"
+        ));
+        assertThat(content).hasSize(2);
+        List<String> existingObjects = new ArrayList<>();
+        for (JsonNode row : content) {
+            existingObjects.add(row.path("existing_object").asText());
+        }
+        assertThat(existingObjects).containsExactlyInAnyOrder("PostgreSQL", "Java");
+        for (JsonNode row : content) {
+            assertThat(row.path("valid_from").asText()).matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?[+-]\\d{2}:\\d{2}");
+        }
     }
 
     @Test
@@ -360,39 +278,15 @@ class WriteToolsIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":5,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_kg_invalidate",
-                                    "arguments":{"fact_id":"00000000-0000-0000-0000-000000000201"}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].invalidated").value(true));
+        JsonNode invalidateContent = callToolContent("writer-token", "hivemem_kg_invalidate", Map.of(
+                "fact_id", "00000000-0000-0000-0000-000000000201"
+        ));
+        assertThat(invalidateContent.path("invalidated").asBoolean()).isTrue();
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":6,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_search_kg",
-                                    "arguments":{"subject":"Transient fact"}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(0));
+        JsonNode searchContent = callToolContent("writer-token", "hivemem_search_kg", Map.of(
+                "subject", "Transient fact"
+        ));
+        assertThat(searchContent).isEmpty();
 
         org.junit.jupiter.api.Assertions.assertNull(dslContext.fetchOne("""
                 SELECT id
@@ -425,26 +319,12 @@ class WriteToolsIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":12,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_revise_fact",
-                                    "arguments":{
-                                      "old_id":"00000000-0000-0000-0000-000000000401",
-                                      "new_object":"Spring Boot"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].old_id").value(oldId.toString()))
-                .andExpect(jsonPath("$.result.content[0].new_id").isString());
+        JsonNode reviseContent = callToolContent("writer-token", "hivemem_revise_fact", Map.of(
+                "old_id", "00000000-0000-0000-0000-000000000401",
+                "new_object", "Spring Boot"
+        ));
+        assertThat(reviseContent.path("old_id").asText()).isEqualTo(oldId.toString());
+        assertThat(reviseContent.path("new_id").asText()).isNotBlank();
 
         Record oldRow = dslContext.fetchOne("""
                 SELECT id, valid_until, subject, predicate, "object", confidence, source_id, status, created_by
@@ -471,24 +351,12 @@ class WriteToolsIntegrationTest {
         org.junit.jupiter.api.Assertions.assertEquals("writer-1", newRow.get("created_by", String.class));
 
         UUID newId = newRow.get("id", UUID.class);
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":13,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_fact_history",
-                                    "arguments":{"fact_id":"%s"}
-                                  }
-                                }
-                                """.formatted(newId)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(2))
-                .andExpect(jsonPath("$.result.content[0][0].id").value(oldId.toString()))
-                .andExpect(jsonPath("$.result.content[0][1].id").value(newId.toString()));
+        JsonNode history = callToolContent("writer-token", "hivemem_fact_history", Map.of(
+                "fact_id", newId.toString()
+        ));
+        assertThat(history).hasSize(2);
+        assertThat(history.get(0).path("id").asText()).isEqualTo(oldId.toString());
+        assertThat(history.get(1).path("id").asText()).isEqualTo(newId.toString());
     }
 
     @Test
@@ -509,26 +377,12 @@ class WriteToolsIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer agent-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":14,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_revise_fact",
-                                    "arguments":{
-                                      "old_id":"00000000-0000-0000-0000-000000000403",
-                                      "new_object":"closed"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].old_id").value(oldId.toString()))
-                .andExpect(jsonPath("$.result.content[0].new_id").isString());
+        JsonNode reviseContent = callToolContent("agent-token", "hivemem_revise_fact", Map.of(
+                "old_id", "00000000-0000-0000-0000-000000000403",
+                "new_object", "closed"
+        ));
+        assertThat(reviseContent.path("old_id").asText()).isEqualTo(oldId.toString());
+        assertThat(reviseContent.path("new_id").asText()).isNotBlank();
 
         Record newRow = dslContext.fetchOne("""
                 SELECT parent_id, "object", status, created_by
@@ -558,69 +412,27 @@ class WriteToolsIntegrationTest {
                 null
         );
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":15,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_revise_fact",
-                                    "arguments":{
-                                      "old_id":"00000000-0000-0000-0000-000000000404",
-                                      "new_object":"Spring Boot"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk());
+        callToolContent("writer-token", "hivemem_revise_fact", Map.of(
+                "old_id", "00000000-0000-0000-0000-000000000404",
+                "new_object", "Spring Boot"
+        ));
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":16,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_check_contradiction",
-                                    "arguments":{
-                                      "subject":"HiveMem",
-                                      "predicate":"runs on",
-                                      "new_object":"Spring Boot"
-                                    }
-                                  }
-                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].length()").value(0));
+        JsonNode content = callToolContent("writer-token", "hivemem_check_contradiction", Map.of(
+                "subject", "HiveMem",
+                "predicate", "runs on",
+                "new_object", "Spring Boot"
+        ));
+        assertThat(content).isEmpty();
     }
 
     @Test
     void writerCanUpsertIdentityAndPersistTokenCount() throws Exception {
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":19,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_update_identity",
-                                    "arguments":{
-                                      "key":"l0_identity",
-                                      "content":"I am HiveMem."
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].key").value("l0_identity"))
-                .andExpect(jsonPath("$.result.content[0].token_count").value(3));
+        JsonNode content = callToolContent("writer-token", "hivemem_update_identity", Map.of(
+                "key", "l0_identity",
+                "content", "I am HiveMem."
+        ));
+        assertThat(content.path("key").asText()).isEqualTo("l0_identity");
+        assertThat(content.path("token_count").asInt()).isEqualTo(3);
 
         Record row = dslContext.fetchOne("""
                 SELECT content, token_count
@@ -641,37 +453,20 @@ class WriteToolsIntegrationTest {
                 OffsetDateTime.parse("2026-04-05T13:00:00Z"),
                 null);
 
-        String referenceId = mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":20,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_add_reference",
-                                    "arguments":{
-                                      "title":"GraphRAG Survey 2024",
-                                      "url":"https://example.com/graphrag",
-                                      "author":"Zhang et al.",
-                                      "ref_type":"paper",
-                                      "status":"unread",
-                                      "notes":"Worth reading",
-                                      "tags":["graph","rag"],
-                                      "importance":2
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].title").value("GraphRAG Survey 2024"))
-                .andExpect(jsonPath("$.result.content[0].status").value("unread"))
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
+        JsonNode refContent = callToolContent("writer-token", "hivemem_add_reference", Map.of(
+                "title", "GraphRAG Survey 2024",
+                "url", "https://example.com/graphrag",
+                "author", "Zhang et al.",
+                "ref_type", "paper",
+                "status", "unread",
+                "notes", "Worth reading",
+                "tags", List.of("graph", "rag"),
+                "importance", 2
+        ));
+        assertThat(refContent.path("title").asText()).isEqualTo("GraphRAG Survey 2024");
+        assertThat(refContent.path("status").asText()).isEqualTo("unread");
 
-        String refId = com.jayway.jsonpath.JsonPath.read(referenceId, "$.result.content[0].id");
+        String refId = refContent.path("id").asText();
         Record referenceRow = dslContext.fetchOne("""
                 SELECT title, url, author, ref_type, status, notes, tags, importance
                 FROM references_
@@ -681,28 +476,14 @@ class WriteToolsIntegrationTest {
         org.junit.jupiter.api.Assertions.assertEquals("GraphRAG Survey 2024", referenceRow.get("title", String.class));
         org.junit.jupiter.api.Assertions.assertEquals("unread", referenceRow.get("status", String.class));
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":21,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_link_reference",
-                                    "arguments":{
-                                      "drawer_id":"00000000-0000-0000-0000-000000000501",
-                                      "reference_id":"%s",
-                                      "relation":"source"
-                                    }
-                                  }
-                                }
-                                """.formatted(refId)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].drawer_id").value(drawerId.toString()))
-                .andExpect(jsonPath("$.result.content[0].reference_id").value(refId))
-                .andExpect(jsonPath("$.result.content[0].relation").value("source"));
+        JsonNode linkContent = callToolContent("writer-token", "hivemem_link_reference", Map.of(
+                "drawer_id", "00000000-0000-0000-0000-000000000501",
+                "reference_id", refId,
+                "relation", "source"
+        ));
+        assertThat(linkContent.path("drawer_id").asText()).isEqualTo(drawerId.toString());
+        assertThat(linkContent.path("reference_id").asText()).isEqualTo(refId);
+        assertThat(linkContent.path("relation").asText()).isEqualTo("source");
 
         Record linkRow = dslContext.fetchOne("""
                 SELECT drawer_id, reference_id, relation
@@ -715,27 +496,13 @@ class WriteToolsIntegrationTest {
 
     @Test
     void writerCanRegisterAgentAndWriteDiaryEntries() throws Exception {
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":22,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_register_agent",
-                                    "arguments":{
-                                      "name":"classifier",
-                                      "focus":"Classify incoming drawers",
-                                      "schedule":"nightly"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].name").value("classifier"))
-                .andExpect(jsonPath("$.result.content[0].focus").value("Classify incoming drawers"));
+        JsonNode agentContent = callToolContent("writer-token", "hivemem_register_agent", Map.of(
+                "name", "classifier",
+                "focus", "Classify incoming drawers",
+                "schedule", "nightly"
+        ));
+        assertThat(agentContent.path("name").asText()).isEqualTo("classifier");
+        assertThat(agentContent.path("focus").asText()).isEqualTo("Classify incoming drawers");
 
         Record agentRow = dslContext.fetchOne("""
                 SELECT focus, schedule
@@ -746,26 +513,12 @@ class WriteToolsIntegrationTest {
         org.junit.jupiter.api.Assertions.assertEquals("Classify incoming drawers", agentRow.get("focus", String.class));
         org.junit.jupiter.api.Assertions.assertEquals("nightly", agentRow.get("schedule", String.class));
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":23,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_diary_write",
-                                    "arguments":{
-                                      "agent":"classifier",
-                                      "entry":"Merged duplicates, kept most recent"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].agent").value("classifier"))
-                .andExpect(jsonPath("$.result.content[0].id").isString());
+        JsonNode diaryContent = callToolContent("writer-token", "hivemem_diary_write", Map.of(
+                "agent", "classifier",
+                "entry", "Merged duplicates, kept most recent"
+        ));
+        assertThat(diaryContent.path("agent").asText()).isEqualTo("classifier");
+        assertThat(diaryContent.path("id").asText()).isNotBlank();
 
         Record diaryRow = dslContext.fetchOne("""
                 SELECT agent, entry
@@ -780,50 +533,22 @@ class WriteToolsIntegrationTest {
 
     @Test
     void writerCanAppendBlueprintsAndClosePreviousVersion() throws Exception {
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":24,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_update_blueprint",
-                                    "arguments":{
-                                      "wing":"eng",
-                                      "title":"V1",
-                                      "narrative":"First version",
-                                      "hall_order":["auth","search"]
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].wing").value("eng"))
-                .andExpect(jsonPath("$.result.content[0].title").value("V1"));
+        JsonNode v1 = callToolContent("writer-token", "hivemem_update_blueprint", Map.of(
+                "wing", "eng",
+                "title", "V1",
+                "narrative", "First version",
+                "hall_order", List.of("auth", "search")
+        ));
+        assertThat(v1.path("wing").asText()).isEqualTo("eng");
+        assertThat(v1.path("title").asText()).isEqualTo("V1");
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":25,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_update_blueprint",
-                                    "arguments":{
-                                      "wing":"eng",
-                                      "title":"V2",
-                                      "narrative":"Updated version",
-                                      "hall_order":["auth","search","infra"]
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].title").value("V2"));
+        JsonNode v2 = callToolContent("writer-token", "hivemem_update_blueprint", Map.of(
+                "wing", "eng",
+                "title", "V2",
+                "narrative", "Updated version",
+                "hall_order", List.of("auth", "search", "infra")
+        ));
+        assertThat(v2.path("title").asText()).isEqualTo("V2");
 
         Record activeRow = dslContext.fetchOne("""
                 SELECT title, valid_until, created_by
@@ -850,31 +575,14 @@ class WriteToolsIntegrationTest {
                 OffsetDateTime.parse("2026-04-05T13:30:00Z"),
                 null);
 
-        String response = mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":251,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_revise_drawer",
-                                    "arguments":{
-                                      "old_id":"00000000-0000-0000-0000-000000000550",
-                                      "new_content":"Drawer V2",
-                                      "new_summary":"Summary V2"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].old_id").value(drawerId.toString()))
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
+        JsonNode reviseContent = callToolContent("writer-token", "hivemem_revise_drawer", Map.of(
+                "old_id", "00000000-0000-0000-0000-000000000550",
+                "new_content", "Drawer V2",
+                "new_summary", "Summary V2"
+        ));
+        assertThat(reviseContent.path("old_id").asText()).isEqualTo(drawerId.toString());
 
-        String newId = com.jayway.jsonpath.JsonPath.read(response, "$.result.content[0].new_id");
+        String newId = reviseContent.path("new_id").asText();
         Record oldRow = dslContext.fetchOne("""
                 SELECT valid_until
                 FROM drawers
@@ -912,33 +620,16 @@ class WriteToolsIntegrationTest {
                 OffsetDateTime.parse("2026-04-05T14:00:00Z"),
                 null);
 
-        String tunnelResponse = mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer agent-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":26,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_add_tunnel",
-                                    "arguments":{
-                                      "from_drawer":"00000000-0000-0000-0000-000000000601",
-                                      "to_drawer":"00000000-0000-0000-0000-000000000602",
-                                      "relation":"related_to",
-                                      "note":"context link",
-                                      "status":"committed"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].status").value("pending"))
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
+        JsonNode tunnelContent = callToolContent("agent-token", "hivemem_add_tunnel", Map.of(
+                "from_drawer", "00000000-0000-0000-0000-000000000601",
+                "to_drawer", "00000000-0000-0000-0000-000000000602",
+                "relation", "related_to",
+                "note", "context link",
+                "status", "committed"
+        ));
+        assertThat(tunnelContent.path("status").asText()).isEqualTo("pending");
 
-        String tunnelId = com.jayway.jsonpath.JsonPath.read(tunnelResponse, "$.result.content[0].id");
+        String tunnelId = tunnelContent.path("id").asText();
         Record tunnelRow = dslContext.fetchOne("""
                 SELECT from_drawer, to_drawer, relation, note, status, created_by, valid_until
                 FROM tunnels
@@ -948,22 +639,10 @@ class WriteToolsIntegrationTest {
         org.junit.jupiter.api.Assertions.assertEquals("pending", tunnelRow.get("status", String.class));
         org.junit.jupiter.api.Assertions.assertEquals("agent-1", tunnelRow.get("created_by", String.class));
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer writer-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":27,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_remove_tunnel",
-                                    "arguments":{"tunnel_id":"%s"}
-                                  }
-                                }
-                                """.formatted(tunnelId)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].removed").value(true));
+        JsonNode removeContent = callToolContent("writer-token", "hivemem_remove_tunnel", Map.of(
+                "tunnel_id", tunnelId
+        ));
+        assertThat(removeContent.path("removed").asBoolean()).isTrue();
 
         Record removedRow = dslContext.fetchOne("""
                 SELECT valid_until
@@ -982,53 +661,19 @@ class WriteToolsIntegrationTest {
                 OffsetDateTime.parse("2026-04-05T15:00:00Z"),
                 null);
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer admin-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":261,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_log_access",
-                                    "arguments":{"drawer_id":"00000000-0000-0000-0000-000000000701"}
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].logged").value(true));
+        JsonNode logContent = callToolContent("admin-token", "hivemem_log_access", Map.of(
+                "drawer_id", "00000000-0000-0000-0000-000000000701"
+        ));
+        assertThat(logContent.path("logged").asBoolean()).isTrue();
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer admin-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":262,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_refresh_popularity","arguments":{}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].refreshed").value(true))
-                .andExpect(jsonPath("$.result.content[0].drawer_count").isNumber());
+        JsonNode refreshContent = callToolContent("admin-token", "hivemem_refresh_popularity", Map.of());
+        assertThat(refreshContent.path("refreshed").asBoolean()).isTrue();
+        assertThat(refreshContent.path("drawer_count").isNumber()).isTrue();
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer admin-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":263,
-                                  "method":"tools/call",
-                                  "params":{"name":"hivemem_health","arguments":{}}
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].db_connected").value(true))
-                .andExpect(jsonPath("$.result.content[0].drawers").value(1))
-                .andExpect(jsonPath("$.result.content[0].facts").value(0));
+        JsonNode healthContent = callToolContent("admin-token", "hivemem_health", Map.of());
+        assertThat(healthContent.path("db_connected").asBoolean()).isTrue();
+        assertThat(healthContent.path("drawers").asInt()).isEqualTo(1);
+        assertThat(healthContent.path("facts").asInt()).isEqualTo(0);
 
         org.junit.jupiter.api.Assertions.assertEquals(1L, dslContext.fetchOne("""
                 SELECT count(*) AS cnt
@@ -1116,30 +761,16 @@ class WriteToolsIntegrationTest {
                 OffsetDateTime.parse("2026-04-01T09:00:00Z"),
                 null);
 
-        mockMvc.perform(post("/mcp")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer admin-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "jsonrpc":"2.0",
-                                  "id":7,
-                                  "method":"tools/call",
-                                  "params":{
-                                    "name":"hivemem_approve_pending",
-                                    "arguments":{
-                                      "ids":[
-                                        "00000000-0000-0000-0000-000000000301",
-                                        "00000000-0000-0000-0000-000000000302",
-                                        "00000000-0000-0000-0000-000000000305"
-                                      ],
-                                      "decision":"committed"
-                                    }
-                                  }
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.content[0].decision").value("committed"))
-                .andExpect(jsonPath("$.result.content[0].count").value(3));
+        JsonNode approveContent = callToolContent("admin-token", "hivemem_approve_pending", Map.of(
+                "ids", List.of(
+                        "00000000-0000-0000-0000-000000000301",
+                        "00000000-0000-0000-0000-000000000302",
+                        "00000000-0000-0000-0000-000000000305"
+                ),
+                "decision", "committed"
+        ));
+        assertThat(approveContent.path("decision").asText()).isEqualTo("committed");
+        assertThat(approveContent.path("count").asInt()).isEqualTo(3);
 
         org.junit.jupiter.api.Assertions.assertEquals("committed", dslContext.fetchOne("""
                 SELECT status FROM drawers WHERE id = ?
@@ -1300,6 +931,26 @@ class WriteToolsIntegrationTest {
                 INSERT INTO tunnels (id, from_drawer, to_drawer, relation, note, status, created_by, valid_from, created_at, valid_until)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?::timestamptz, ?::timestamptz, ?::timestamptz)
                 """, id, fromDrawer, toDrawer, relation, note, status, createdBy, validFrom, createdAt, validUntil);
+    }
+
+    private JsonNode callToolContent(String token, String toolName, Map<String, Object> arguments) throws Exception {
+        MvcResult result = mockMvc.perform(post("/mcp")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "jsonrpc", "2.0",
+                                "id", 1,
+                                "method", "tools/call",
+                                "params", Map.of(
+                                        "name", toolName,
+                                        "arguments", arguments
+                                )
+                        ))))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        String textContent = body.path("result").path("content").get(0).path("text").asText();
+        return objectMapper.readTree(textContent);
     }
 
     @TestConfiguration(proxyBeanMethods = false)

--- a/java-server/src/test/java/com/hivemem/tools/write/WriteToolsIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/write/WriteToolsIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
## Summary

- Upgrade Java 21 → 25, Spring Boot 3.3.5 → 4.0.5, Jackson 2 → 3
- Migrate 45 source files from `com.fasterxml.jackson.databind` to `tools.jackson.databind`
- Migrate test infrastructure: `@MockBean` → `@MockitoBean`, `AutoConfigureMockMvc` package move
- Add `spring-boot-starter-restclient` + `spring-boot-starter-flyway` (Spring Boot 4.0 modularized auto-configs)
- Add `spring-boot-starter-webmvc-test` (test autoconfigure split)
- Testcontainers 2.0 artifact rename (`postgresql` → `testcontainers-postgresql`)
- JaCoCo 0.8.12 → 0.8.13 (Java 25 bytecode support)
- CI pipeline updated to JDK 25
- Local deploy.sh uses 2-step build (apparmor workaround for JDK 25 on LXC)
- Artifact version bumped to 4.0.0

## Breaking Changes

- Jackson 3 package names (`tools.jackson.databind` replaces `com.fasterxml.jackson.databind`)
- Spring Framework 7.x / Jakarta EE 11
- `@MockBean` → `@MockitoBean` in tests

## Test plan

- [x] All 250 tests pass locally with JDK 25
- [ ] CI pipeline passes (Java 25 + Testcontainers)
- [x] Docker image builds successfully (2-step on LXC)
- [ ] Deploy to CT 102 and verify MCP endpoint