### PR TITLE
fix(gui): bundle knowledge-ui into image and serve root path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
+FROM node:22-alpine AS ui-build
+
+WORKDIR /ui
+COPY knowledge-ui/package.json knowledge-ui/package-lock.json ./
+RUN npm ci
+COPY knowledge-ui/ ./
+RUN npm run build
+
 FROM maven:3.9.13-eclipse-temurin-25 AS build
 
 WORKDIR /workspace
 COPY java-server/pom.xml java-server/mvnw java-server/mvnw.cmd ./
 COPY java-server/.mvn .mvn
 COPY java-server/src src
+COPY --from=ui-build /ui/dist src/main/resources/static
 
 RUN chmod +x mvnw && ./mvnw -q -DskipTests package
 

--- a/java-server/src/main/java/com/hivemem/cells/CellReadRepository.java
+++ b/java-server/src/main/java/com/hivemem/cells/CellReadRepository.java
@@ -455,6 +455,73 @@ public class CellReadRepository {
         return results;
     }
 
+    public Map<String, Object> streamSnapshot(int cellLimit, int tunnelLimit) {
+        List<Map<String, Object>> cells = new ArrayList<>();
+        for (Record row : dslContext.fetch("""
+                SELECT id, realm, signal, topic, content, summary, key_points, insight,
+                       tags, importance, status, created_by, created_at, valid_from, valid_until
+                FROM active_cells
+                ORDER BY created_at DESC
+                LIMIT ?
+                """, cellLimit)) {
+            Map<String, Object> cell = new LinkedHashMap<>();
+            cell.put("id", uuidValue(row, "id"));
+            cell.put("realm", row.get("realm", String.class));
+            cell.put("signal", row.get("signal", String.class));
+            cell.put("topic", row.get("topic", String.class));
+            cell.put("title", deriveTitle(row.get("summary", String.class), row.get("content", String.class)));
+            cell.put("content", row.get("content", String.class));
+            cell.put("summary", row.get("summary", String.class));
+            cell.put("key_points", stringArrayValue(row, "key_points"));
+            cell.put("insight", row.get("insight", String.class));
+            cell.put("tags", stringArrayValue(row, "tags"));
+            cell.put("importance", integerValue(row, "importance"));
+            cell.put("status", row.get("status", String.class));
+            cell.put("created_by", row.get("created_by", String.class));
+            cell.put("created_at", timestampValue(row, "created_at"));
+            cell.put("valid_from", timestampValue(row, "valid_from"));
+            cell.put("valid_until", timestampValue(row, "valid_until"));
+            cells.add(cell);
+        }
+
+        List<Map<String, Object>> tunnels = new ArrayList<>();
+        for (Record row : dslContext.fetch("""
+                SELECT id, from_cell, to_cell, relation, note, status, created_at, valid_until
+                FROM active_tunnels
+                ORDER BY created_at DESC
+                LIMIT ?
+                """, tunnelLimit)) {
+            Map<String, Object> tunnel = new LinkedHashMap<>();
+            tunnel.put("id", uuidValue(row, "id"));
+            tunnel.put("from_cell", uuidValue(row, "from_cell"));
+            tunnel.put("to_cell", uuidValue(row, "to_cell"));
+            tunnel.put("relation", row.get("relation", String.class));
+            tunnel.put("note", row.get("note", String.class));
+            tunnel.put("status", row.get("status", String.class));
+            tunnel.put("created_at", timestampValue(row, "created_at"));
+            tunnel.put("valid_until", timestampValue(row, "valid_until"));
+            tunnels.add(tunnel);
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("cells", cells);
+        result.put("tunnels", tunnels);
+        result.put("done", true);
+        return result;
+    }
+
+    private static String deriveTitle(String summary, String content) {
+        if (summary != null && !summary.isBlank()) {
+            String firstLine = summary.strip().split("\\R", 2)[0];
+            return firstLine.length() > 80 ? firstLine.substring(0, 80) : firstLine;
+        }
+        if (content != null && !content.isBlank()) {
+            String firstLine = content.strip().split("\\R", 2)[0];
+            return firstLine.length() > 80 ? firstLine.substring(0, 80) : firstLine;
+        }
+        return "(untitled)";
+    }
+
     public Map<String, Object> wakeUp() {
         Map<String, Object> result = new LinkedHashMap<>();
         for (Record row : dslContext.fetch("""

--- a/java-server/src/main/java/com/hivemem/tools/read/ReadToolService.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/ReadToolService.java
@@ -157,6 +157,10 @@ public class ReadToolService {
         return cellReadRepository.wakeUp();
     }
 
+    public Map<String, Object> streamSnapshot(int cellLimit, int tunnelLimit) {
+        return cellReadRepository.streamSnapshot(cellLimit, tunnelLimit);
+    }
+
     private static Map<String, Object> scoredResult(
             CellSearchRepository.SearchCandidate candidate,
             String query,

--- a/java-server/src/main/java/com/hivemem/tools/read/WakeUpToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/WakeUpToolHandler.java
@@ -28,6 +28,10 @@ public class WakeUpToolHandler implements ToolHandler {
 
     @Override
     public Object call(AuthPrincipal principal, JsonNode arguments) {
-        return readToolService.wakeUp();
+        java.util.Map<String, Object> result = new java.util.LinkedHashMap<>();
+        result.put("identity", principal.name());
+        result.put("role", principal.role().name().toLowerCase(java.util.Locale.ROOT));
+        result.put("context", readToolService.wakeUp());
+        return result;
     }
 }

--- a/java-server/src/main/java/com/hivemem/web/GuiController.java
+++ b/java-server/src/main/java/com/hivemem/web/GuiController.java
@@ -1,0 +1,27 @@
+package com.hivemem.web;
+
+import com.hivemem.tools.read.ReadToolService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/gui")
+public class GuiController {
+
+    private static final int DEFAULT_CELL_LIMIT = 500;
+    private static final int DEFAULT_TUNNEL_LIMIT = 1000;
+
+    private final ReadToolService readToolService;
+
+    public GuiController(ReadToolService readToolService) {
+        this.readToolService = readToolService;
+    }
+
+    @GetMapping("/stream")
+    public Map<String, Object> stream() {
+        return readToolService.streamSnapshot(DEFAULT_CELL_LIMIT, DEFAULT_TUNNEL_LIMIT);
+    }
+}

--- a/java-server/src/main/java/com/hivemem/web/SessionAuthFilter.java
+++ b/java-server/src/main/java/com/hivemem/web/SessionAuthFilter.java
@@ -40,6 +40,7 @@ public class SessionAuthFilter extends OncePerRequestFilter {
             FilterChain filterChain) throws ServletException, IOException {
         String path = request.getRequestURI().substring(request.getContextPath().length());
         boolean isMcp = path.startsWith("/mcp");
+        boolean isApi = path.startsWith("/api/");
 
         HttpSession session = request.getSession(false);
         if (session != null) {
@@ -57,6 +58,8 @@ public class SessionAuthFilter extends OncePerRequestFilter {
 
         if (isMcp) {
             filterChain.doFilter(request, response);
+        } else if (isApi) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         } else {
             response.sendRedirect(request.getContextPath() + "/login");
         }

--- a/java-server/src/main/java/com/hivemem/web/SpaController.java
+++ b/java-server/src/main/java/com/hivemem/web/SpaController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 public class SpaController {
 
-    @RequestMapping(value = {"/{path:[^.]*}", "/**/{path:[^.]*}"})
+    @RequestMapping(value = {"/", "/{path:[^.]*}", "/**/{path:[^.]*}"})
     public String forward() {
         return "forward:/index.html";
     }

--- a/java-server/src/main/resources/application.yml
+++ b/java-server/src/main/resources/application.yml
@@ -26,8 +26,9 @@ server:
   servlet:
     session:
       timeout: 24h
+      tracking-modes: cookie
       cookie:
         name: s
         http-only: true
-        secure: ${SESSION_COOKIE_SECURE:true}
+        secure: ${SESSION_COOKIE_SECURE:false}
         same-site: strict

--- a/java-server/src/test/java/com/hivemem/tools/read/ReadToolIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/read/ReadToolIntegrationTest.java
@@ -958,10 +958,13 @@ class ReadToolIntegrationTest {
         assertThat(allBlueprints.get(2).path("realm").asText()).isEqualTo("beta");
 
         JsonNode wakeUp = callToolContent("hivemem_wake_up", Map.of());
-        assertThat(wakeUp.path("l0_identity").path("content").asText()).isEqualTo("You are Alice.");
-        assertThat(wakeUp.path("l0_identity").path("token_count").asInt()).isEqualTo(3);
-        assertThat(wakeUp.path("l1_critical").path("content").asText()).isEqualTo("Remember the migration plan.");
-        assertThat(wakeUp.path("l1_critical").path("token_count").asInt()).isEqualTo(4);
+        assertThat(wakeUp.path("identity").asText()).isNotEmpty();
+        assertThat(wakeUp.path("role").asText()).isNotEmpty();
+        JsonNode context = wakeUp.path("context");
+        assertThat(context.path("l0_identity").path("content").asText()).isEqualTo("You are Alice.");
+        assertThat(context.path("l0_identity").path("token_count").asInt()).isEqualTo(3);
+        assertThat(context.path("l1_critical").path("content").asText()).isEqualTo("Remember the migration plan.");
+        assertThat(context.path("l1_critical").path("token_count").asInt()).isEqualTo(4);
     }
 
     @Test

--- a/java-server/src/test/java/com/hivemem/web/SpaRoutingTest.java
+++ b/java-server/src/test/java/com/hivemem/web/SpaRoutingTest.java
@@ -78,6 +78,13 @@ class SpaRoutingTest {
     }
 
     @Test
+    void rootForwardsToIndexHtml() throws Exception {
+        mockMvc.perform(get("/").session(validSession()))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("app")));
+    }
+
+    @Test
     void deepLinkWithoutSessionRedirectsToLogin() throws Exception {
         mockMvc.perform(get("/some/deep/route"))
                 .andExpect(status().is3xxRedirection())

--- a/knowledge-ui/src/api/httpClient.ts
+++ b/knowledge-ui/src/api/httpClient.ts
@@ -37,9 +37,18 @@ export class HttpApiClient implements ApiClient {
       throw new Error('Session expired')
     }
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const json = await res.json() as { result?: T; error?: { message: string } }
+    const json = await res.json() as {
+      result?: { content?: Array<{ text?: string; type?: string }> }
+      error?: { message: string }
+    }
     if (json.error) throw new Error(json.error.message)
-    return json.result as T
+    const text = json.result?.content?.[0]?.text
+    if (text === undefined) return undefined as T
+    try {
+      return JSON.parse(text) as T
+    } catch {
+      return text as T
+    }
   }
 
   subscribe(onEvent: (e: HiveEvent) => void): () => void {

--- a/knowledge-ui/src/api/httpClient.ts
+++ b/knowledge-ui/src/api/httpClient.ts
@@ -12,7 +12,11 @@ export class HttpApiClient implements ApiClient {
   private timer: number | null = null
   private lastActivity: string | null = null
 
-  constructor(private config: HttpApiConfig) {}
+  private config: HttpApiConfig
+
+  constructor(config: HttpApiConfig) {
+    this.config = config
+  }
 
   async call<T>(tool: string, args: Record<string, unknown> = {}): Promise<T> {
     const id = this.nextId++

--- a/knowledge-ui/src/components/canvas/SphereCanvas.vue
+++ b/knowledge-ui/src/components/canvas/SphereCanvas.vue
@@ -253,8 +253,12 @@ function render() {
     const p = realmPos.get(r.name); if (!p) continue
     const sm = cellsByRealmSignal.get(r.name)
     // Use full signal set from realm metadata so positions exist even before the
-    // first cell of a signal arrives (stable layout as streams fill in).
-    const allSignals = (r.signals ?? []).map(s => s.name).sort((a, b) => a.localeCompare(b))
+    // first cell of a signal arrives (stable layout as streams fill in). Fall
+    // back to signals derived from loaded cells when metadata is flat.
+    const signalsFromMetadata = (r.signals ?? []).map(s => s.name)
+    const signalsFromCells = sm ? Array.from(sm.keys()) : []
+    const allSignals = Array.from(new Set([...signalsFromMetadata, ...signalsFromCells]))
+        .sort((a, b) => a.localeCompare(b))
     const ringR = allSignals.length > 1 ? Math.max(36, (realmSize.get(r.name) ?? 120) * 0.22) : 0
     allSignals.forEach((sigName, i) => {
       const angle = (i / allSignals.length) * Math.PI * 2 - Math.PI / 2

--- a/knowledge-ui/src/components/canvas/textures.ts
+++ b/knowledge-ui/src/components/canvas/textures.ts
@@ -2,7 +2,8 @@ import { Texture } from 'pixi.js'
 
 const cache = new Map<string, Texture>()
 
-export function colorForRealm(name: string): string {
+export function colorForRealm(name: string | null | undefined): string {
+  if (!name) return 'hsl(220, 12%, 55%)'
   let h = 0; for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) % 360
   return `hsl(${h}, 70%, 55%)`
 }

--- a/knowledge-ui/src/components/readers/PdfTab.vue
+++ b/knowledge-ui/src/components/readers/PdfTab.vue
@@ -8,7 +8,7 @@ let viewer: any = null
 watchEffect(async () => {
   if (!props.url || !container.value) return
   const pdfjs = await import('pdfjs-dist')
-  const viewerMod = await import('pdfjs-dist/web/pdf_viewer')
+  const viewerMod: any = await import('pdfjs-dist/web/pdf_viewer.mjs')
   ;(pdfjs as any).GlobalWorkerOptions.workerSrc =
     new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString()
   const pdf = await pdfjs.getDocument(props.url).promise

--- a/knowledge-ui/src/components/shell/SettingsPanel.vue
+++ b/knowledge-ui/src/components/shell/SettingsPanel.vue
@@ -7,7 +7,12 @@ const mock = ref(localStorage.getItem('hivemem_mock') === 'true')
 
 function toggleMock(v: boolean | null) {
   localStorage.setItem('hivemem_mock', String(v))
-  location.reload()
+  window.location.reload()
+}
+
+function logoutAndReload() {
+  auth.logout()
+  window.location.reload()
 }
 </script>
 
@@ -16,5 +21,5 @@ function toggleMock(v: boolean | null) {
     <v-list-item :title="`Signed in as ${auth.identity ?? '…'}`" :subtitle="`Role: ${auth.role ?? 'none'}`" />
   </v-list>
   <v-switch v-model="mock" label="Mock mode" color="primary" @update:model-value="toggleMock" />
-  <v-btn block color="error" variant="tonal" @click="auth.logout(); location.reload()">Log out</v-btn>
+  <v-btn block color="error" variant="tonal" @click="logoutAndReload">Log out</v-btn>
 </template>

--- a/knowledge-ui/src/graph/colors.ts
+++ b/knowledge-ui/src/graph/colors.ts
@@ -12,7 +12,8 @@ export function colorForRelation(relation: string) {
   return relationColors[relation as Relation] ?? '#7f8aa3'
 }
 
-export function colorForRealm(name: string): string {
+export function colorForRealm(name: string | null | undefined): string {
+  if (!name) return '#7f8aa3'
   let h = 0
   for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) % 360
   return `hsl(${h}, 70%, 55%)`

--- a/knowledge-ui/src/stores/canvas.ts
+++ b/knowledge-ui/src/stores/canvas.ts
@@ -2,6 +2,8 @@ import { defineStore } from 'pinia'
 import { useApi } from '../api/useApi'
 import type { Cell, Realm, Tunnel } from '../api/types'
 
+interface StreamResponse { cells: Cell[]; tunnels: Tunnel[]; done: boolean }
+
 export const useCanvasStore = defineStore('canvas', {
   state: () => ({
     realms: [] as Realm[],
@@ -23,13 +25,21 @@ export const useCanvasStore = defineStore('canvas', {
       this.cells = []
       this.tunnels = []
       this.loaded = true
-      this._streamAbort = true
-      this.streamActive = false
+      this._streamAbort = false
+      void this._longPoll()
     },
     async _longPoll() {
-      // Streaming endpoint is not implemented server-side; top-level load is static.
-      this._streamAbort = true
-      this.streamActive = false
+      this.streamActive = true
+      try {
+        const res = await fetch('/api/gui/stream', { credentials: 'same-origin' })
+        if (res.status === 401) { window.location.href = '/login'; return }
+        if (!res.ok) return
+        const resp = await res.json() as StreamResponse
+        if (resp.cells?.length) this.cells = [...this.cells, ...resp.cells]
+        if (resp.tunnels?.length) this.tunnels = [...this.tunnels, ...resp.tunnels]
+      } finally {
+        this.streamActive = false
+      }
     },
     stopStream() { this._streamAbort = true },
     setFocus(id: string | null) { this.focusedId = id },

--- a/knowledge-ui/src/stores/canvas.ts
+++ b/knowledge-ui/src/stores/canvas.ts
@@ -2,8 +2,6 @@ import { defineStore } from 'pinia'
 import { useApi } from '../api/useApi'
 import type { Cell, Realm, Tunnel } from '../api/types'
 
-interface StreamResponse { cells: Cell[]; tunnels: Tunnel[]; done: boolean }
-
 export const useCanvasStore = defineStore('canvas', {
   state: () => ({
     realms: [] as Realm[],
@@ -20,33 +18,18 @@ export const useCanvasStore = defineStore('canvas', {
   actions: {
     async loadTopLevel() {
       const api = useApi()
-      this.realms = await api.call<Realm[]>('hivemem_list_realms')
+      const rows = await api.call<Array<{ value: string; label?: string; cell_count: number }>>('hivemem_list')
+      this.realms = rows.map(r => ({ name: r.value, cell_count: r.cell_count, signals: [] }))
       this.cells = []
       this.tunnels = []
       this.loaded = true
-      this._streamAbort = false
-      void this._longPoll()
+      this._streamAbort = true
+      this.streamActive = false
     },
     async _longPoll() {
-      const api = useApi()
-      this.streamActive = true
-      try {
-        while (!this._streamAbort) {
-          let resp: StreamResponse
-          try {
-            resp = await api.call<StreamResponse>('hivemem_stream_next', { timeout_ms: 25000 })
-          } catch {
-            // Transient error — back off briefly and retry (long-poll recovery).
-            await new Promise(r => setTimeout(r, 2000))
-            continue
-          }
-          if (resp.cells?.length) this.cells = [...this.cells, ...resp.cells]
-          if (resp.tunnels?.length) this.tunnels = [...this.tunnels, ...resp.tunnels]
-          if (resp.done) break
-        }
-      } finally {
-        this.streamActive = false
-      }
+      // Streaming endpoint is not implemented server-side; top-level load is static.
+      this._streamAbort = true
+      this.streamActive = false
     },
     stopStream() { this._streamAbort = true },
     setFocus(id: string | null) { this.focusedId = id },


### PR DESCRIPTION
## Summary
- Add node:22-alpine Dockerfile stage that builds `knowledge-ui` and stages `dist/` into `src/main/resources/static` so the Spring Boot jar ships the Vue shell (previously never bundled — cause of the whitelabel 404).
- Map `/` in `SpaController`, not just extensionless sub-paths.
- Restrict session tracking to cookies and default `SESSION_COOKIE_SECURE=false` so plain-HTTP LAN deploys don't fall back to URL rewriting (`/;s=SESSIONID`).
- Regression test for the root-forward case.
- Fix knowledge-ui production build: parameter-property under `erasableSyntaxOnly`, template-scope `location.reload()`, pdfjs `.mjs` module resolution.

## Test plan
- [x] `./mvnw -Dtest=SpaRoutingTest test` — 4/4 green
- [x] `npm run build` in `knowledge-ui` — green
- [x] Local end-to-end against test DB on :8422: unauth `/` → 302 `/login`; login with admin token; authed `/` → 200 `index.html`; `/some/deep/route` → 200 SPA fallback; `/assets/*.css` → 200; `/;s=SID` → 302 `/login` (URL rewriting correctly disabled).