### PR TITLE
perf(search): replace in-memory ranking with SQL ranked_search()

### DIFF
--- a/java-server/src/main/java/com/hivemem/search/CellSearchRepository.java
+++ b/java-server/src/main/java/com/hivemem/search/CellSearchRepository.java
@@ -1,6 +1,5 @@
 package com.hivemem.search;
 
-import com.hivemem.tools.read.CellFieldSelection;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.springframework.stereotype.Repository;
@@ -20,107 +19,93 @@ public class CellSearchRepository {
         this.dslContext = dslContext;
     }
 
-    public List<SearchCandidate> searchCandidates(String realm, String signal, String topic, CellFieldSelection selection) {
-        List<Object> params = new ArrayList<>();
-        StringBuilder sql = new StringBuilder("""
-                SELECT c.id, c.realm, c.signal, c.topic,
-                       %s,
-                       %s,
-                       %s,
-                       %s,
-                       %s,
-                       %s,
-                       %s,
-                       c.content AS ranking_content,
-                       c.summary AS ranking_summary,
-                       c.tags AS ranking_tags,
-                       c.embedding::real[] AS embedding,
-                       COALESCE(cp.access_count, 0) AS access_count
-                FROM cells c
-                LEFT JOIN cell_popularity cp ON cp.cell_id = c.id
-                WHERE c.status = 'committed'
-                  AND (c.valid_until IS NULL OR c.valid_until > now())
-                """.formatted(
-                textProjection("content", selection),
-                textProjection("summary", selection),
-                textArrayProjection("tags", selection),
-                integerProjection("importance", selection),
-                timestampProjection("created_at", selection),
-                timestampProjection("valid_from", selection),
-                timestampProjection("valid_until", selection)
-        ));
-        if (realm != null) {
-            sql.append(" AND c.realm = ?");
-            params.add(realm);
-        }
-        if (signal != null) {
-            sql.append(" AND c.signal = ?");
-            params.add(signal);
-        }
-        if (topic != null) {
-            sql.append(" AND c.topic = ?");
-            params.add(topic);
-        }
-        sql.append(" ORDER BY c.created_at DESC");
+    /**
+     * Calls the {@code ranked_search} PL/pgSQL function (see V0012 migration), which
+     * performs the full 5-signal ranking inside Postgres against the {@code cells}
+     * table using pgvector cosine distance and tsvector keyword scoring.
+     *
+     * <p>The function applies a hard filter ({@code semantic > 0.3 OR keyword > 0})
+     * and orders deterministically by total score then id.
+     */
+    public List<RankedRow> rankedSearch(
+            List<Float> queryEmbedding,
+            String queryText,
+            String realm,
+            String signal,
+            String topic,
+            int limit,
+            double weightSemantic,
+            double weightKeyword,
+            double weightRecency,
+            double weightImportance,
+            double weightPopularity
+    ) {
+        Float[] embeddingArray = queryEmbedding == null ? null : queryEmbedding.toArray(Float[]::new);
+        String sql = """
+                SELECT id, content, summary, realm, signal, topic, tags, importance,
+                       created_at, valid_from, valid_until,
+                       score_semantic, score_keyword, score_recency,
+                       score_importance, score_popularity, score_total
+                FROM ranked_search(?::vector, ?, ?, ?, ?, ?, ?::real, ?::real, ?::real, ?::real, ?::real)
+                """;
 
-        List<SearchCandidate> results = new ArrayList<>();
-        for (Record row : dslContext.fetch(sql.toString(), params.toArray())) {
-            results.add(new SearchCandidate(
+        List<RankedRow> rows = new ArrayList<>();
+        for (Record row : dslContext.fetch(
+                sql,
+                embeddingArray,
+                queryText,
+                realm,
+                signal,
+                topic,
+                limit,
+                (float) weightSemantic,
+                (float) weightKeyword,
+                (float) weightRecency,
+                (float) weightImportance,
+                (float) weightPopularity
+        )) {
+            rows.add(new RankedRow(
                     row.get("id", UUID.class),
+                    row.get("content", String.class),
+                    row.get("summary", String.class),
                     row.get("realm", String.class),
                     row.get("signal", String.class),
                     row.get("topic", String.class),
-                    row.get("content", String.class),
-                    row.get("summary", String.class),
                     textArray(row, "tags"),
                     row.get("importance", Integer.class),
                     row.get("created_at", OffsetDateTime.class),
                     row.get("valid_from", OffsetDateTime.class),
                     row.get("valid_until", OffsetDateTime.class),
-                    row.get("ranking_content", String.class),
-                    row.get("ranking_summary", String.class),
-                    textArray(row, "ranking_tags"),
-                    floatArray(row, "embedding"),
-                    longValue(row, "access_count")
+                    doubleValue(row, "score_semantic"),
+                    doubleValue(row, "score_keyword"),
+                    doubleValue(row, "score_recency"),
+                    doubleValue(row, "score_importance"),
+                    doubleValue(row, "score_popularity"),
+                    doubleValue(row, "score_total")
             ));
         }
-        return results;
+        return rows;
     }
 
-    public record SearchCandidate(
+    public record RankedRow(
             UUID id,
+            String content,
+            String summary,
             String realm,
             String signal,
             String topic,
-            String content,
-            String summary,
             List<String> tags,
             Integer importance,
             OffsetDateTime createdAt,
             OffsetDateTime validFrom,
             OffsetDateTime validUntil,
-            String rankingContent,
-            String rankingSummary,
-            List<String> rankingTags,
-            List<Float> embedding,
-            long accessCount
+            double scoreSemantic,
+            double scoreKeyword,
+            double scoreRecency,
+            double scoreImportance,
+            double scorePopularity,
+            double scoreTotal
     ) {
-    }
-
-    private static String textProjection(String field, CellFieldSelection selection) {
-        return selection.includes(field) ? "c.%s AS %s".formatted(field, field) : "NULL::text AS %s".formatted(field);
-    }
-
-    private static String textArrayProjection(String field, CellFieldSelection selection) {
-        return selection.includes(field) ? "c.%s AS %s".formatted(field, field) : "NULL::text[] AS %s".formatted(field);
-    }
-
-    private static String integerProjection(String field, CellFieldSelection selection) {
-        return selection.includes(field) ? "c.%s AS %s".formatted(field, field) : "NULL::integer AS %s".formatted(field);
-    }
-
-    private static String timestampProjection(String field, CellFieldSelection selection) {
-        return selection.includes(field) ? "c.%s AS %s".formatted(field, field) : "NULL::timestamptz AS %s".formatted(field);
     }
 
     private static List<String> textArray(Record row, String field) {
@@ -128,16 +113,8 @@ public class CellSearchRepository {
         return values == null ? List.of() : Arrays.asList(values);
     }
 
-    private static List<Float> floatArray(Record row, String field) {
-        Float[] values = row.get(field, Float[].class);
-        if (values == null) {
-            return null;
-        }
-        return Arrays.asList(values);
-    }
-
-    private static long longValue(Record row, String field) {
+    private static double doubleValue(Record row, String field) {
         Number value = row.get(field, Number.class);
-        return value == null ? 0L : value.longValue();
+        return value == null ? 0.0d : value.doubleValue();
     }
 }

--- a/java-server/src/main/java/com/hivemem/tools/read/ReadToolService.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/ReadToolService.java
@@ -9,12 +9,10 @@ import com.hivemem.write.AdminToolService;
 import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 
 @Service
@@ -74,29 +72,11 @@ public class ReadToolService {
             double weightPopularity
     ) {
         List<Float> queryVector = embeddingClient.encodeQuery(query);
-        List<CellSearchRepository.SearchCandidate> candidates = cellSearchRepository.searchCandidates(realm, signal, topic, selection);
-        long maxAccessCount = candidates.stream().mapToLong(CellSearchRepository.SearchCandidate::accessCount).max().orElse(0L);
-        OffsetDateTime now = OffsetDateTime.now();
-
-        return candidates.stream()
-                .map(candidate -> scoredResult(
-                        candidate,
-                        query,
-                        queryVector,
-                        candidate.embedding() == null ? embeddingClient.encodeDocument(candidate.rankingContent()) : candidate.embedding(),
-                        now,
-                        maxAccessCount,
-                        selection,
-                        weightSemantic,
-                        weightKeyword,
-                        weightRecency,
-                        weightImportance,
-                        weightPopularity
-                ))
-                .sorted(Comparator.comparing((Map<String, Object> row) -> ((Number) row.get("score_total")).doubleValue()).reversed()
-                        .thenComparing(row -> (String) row.get("id")))
-                .limit(limit)
-                .toList();
+        List<CellSearchRepository.RankedRow> rows = cellSearchRepository.rankedSearch(
+                queryVector, query, realm, signal, topic, limit,
+                weightSemantic, weightKeyword, weightRecency, weightImportance, weightPopularity
+        );
+        return rows.stream().map(row -> projectRow(row, selection)).toList();
     }
 
     public List<Map<String, Object>> searchKg(String subject, String predicate, String object_, int limit) {
@@ -161,109 +141,27 @@ public class ReadToolService {
         return cellReadRepository.streamSnapshot(cellLimit, tunnelLimit);
     }
 
-    private static Map<String, Object> scoredResult(
-            CellSearchRepository.SearchCandidate candidate,
-            String query,
-            List<Float> queryVector,
-            List<Float> candidateVector,
-            OffsetDateTime newest,
-            long maxAccessCount,
-            CellFieldSelection selection,
-            double weightSemantic,
-            double weightKeyword,
-            double weightRecency,
-            double weightImportance,
-            double weightPopularity
-    ) {
-        double semantic = cosineSimilarity(queryVector, candidateVector);
-        double keyword = keywordScore(query, candidate.rankingContent(), candidate.rankingSummary(), candidate.rankingTags());
-        double recency = recencyScore(candidate.createdAt(), newest);
-        double importance = importanceScore(candidate.importance());
-        double popularity = maxAccessCount <= 0L ? 0.0d : (double) candidate.accessCount() / (double) maxAccessCount;
-        double total = (semantic * weightSemantic)
-                + (keyword * weightKeyword)
-                + (recency * weightRecency)
-                + (importance * weightImportance)
-                + (popularity * weightPopularity);
-
+    private static Map<String, Object> projectRow(CellSearchRepository.RankedRow row, CellFieldSelection selection) {
         Map<String, Object> values = new LinkedHashMap<>();
-        values.put("id", candidate.id().toString());
-        values.put("realm", candidate.realm());
-        values.put("signal", candidate.signal());
-        values.put("topic", candidate.topic());
-        values.put("content", candidate.content());
-        values.put("summary", candidate.summary());
-        values.put("tags", candidate.tags());
-        values.put("importance", candidate.importance());
-        values.put("created_at", candidate.createdAt() == null ? null : candidate.createdAt().toString());
-        values.put("valid_from", candidate.validFrom() == null ? null : candidate.validFrom().toString());
-        values.put("valid_until", candidate.validUntil() == null ? null : candidate.validUntil().toString());
-        Map<String, Object> row = new LinkedHashMap<>(selection.project(values));
-        row.put("score_semantic", rounded(semantic));
-        row.put("score_keyword", rounded(keyword));
-        row.put("score_recency", rounded(recency));
-        row.put("score_importance", rounded(importance));
-        row.put("score_popularity", rounded(popularity));
-        row.put("score_total", rounded(total));
-        return row;
-    }
-
-    private static double cosineSimilarity(List<Float> left, List<Float> right) {
-        if (left == null || right == null || left.isEmpty() || right.isEmpty()) {
-            return 0.0d;
-        }
-        int size = Math.min(left.size(), right.size());
-        double dot = 0.0d;
-        double leftNorm = 0.0d;
-        double rightNorm = 0.0d;
-        for (int i = 0; i < size; i++) {
-            double a = left.get(i);
-            double b = right.get(i);
-            dot += a * b;
-            leftNorm += a * a;
-            rightNorm += b * b;
-        }
-        if (leftNorm == 0.0d || rightNorm == 0.0d) {
-            return 0.0d;
-        }
-        return dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm));
-    }
-
-    private static double keywordScore(String query, String content, String summary, List<String> tags) {
-        List<String> tokens = java.util.Arrays.stream(query.toLowerCase().split("\\s+"))
-                .filter(token -> !token.isBlank())
-                .toList();
-        if (tokens.isEmpty()) {
-            return 0.0d;
-        }
-        String haystack = String.join(" ",
-                content == null ? "" : content.toLowerCase(),
-                summary == null ? "" : summary.toLowerCase(),
-                String.join(" ", tags == null ? List.of() : tags).toLowerCase());
-        long matches = tokens.stream().filter(haystack::contains).count();
-        return (double) matches / (double) tokens.size();
-    }
-
-    private static double recencyScore(OffsetDateTime createdAt, OffsetDateTime reference) {
-        if (createdAt == null || reference == null) {
-            return 0.0d;
-        }
-        long ageSeconds = Math.max(0L, ChronoUnit.SECONDS.between(createdAt, reference));
-        return Math.exp(-0.693d * ageSeconds / (90.0d * 86400.0d));
-    }
-
-    private static double importanceScore(Integer importance) {
-        if (importance == null) {
-            return 0.6d;
-        }
-        return switch (importance) {
-            case 1 -> 1.0d;
-            case 2 -> 0.8d;
-            case 3 -> 0.6d;
-            case 4 -> 0.4d;
-            case 5 -> 0.2d;
-            default -> 0.6d;
-        };
+        values.put("id", row.id().toString());
+        values.put("realm", row.realm());
+        values.put("signal", row.signal());
+        values.put("topic", row.topic());
+        values.put("content", row.content());
+        values.put("summary", row.summary());
+        values.put("tags", row.tags());
+        values.put("importance", row.importance());
+        values.put("created_at", row.createdAt() == null ? null : row.createdAt().toString());
+        values.put("valid_from", row.validFrom() == null ? null : row.validFrom().toString());
+        values.put("valid_until", row.validUntil() == null ? null : row.validUntil().toString());
+        Map<String, Object> projected = new LinkedHashMap<>(selection.project(values));
+        projected.put("score_semantic", rounded(row.scoreSemantic()));
+        projected.put("score_keyword", rounded(row.scoreKeyword()));
+        projected.put("score_recency", rounded(row.scoreRecency()));
+        projected.put("score_importance", rounded(row.scoreImportance()));
+        projected.put("score_popularity", rounded(row.scorePopularity()));
+        projected.put("score_total", rounded(row.scoreTotal()));
+        return projected;
     }
 
     private static double rounded(double value) {

--- a/java-server/src/main/resources/db/migration/V0012__ranked_search_extend.sql
+++ b/java-server/src/main/resources/db/migration/V0012__ranked_search_extend.sql
@@ -1,0 +1,75 @@
+-- V0012: ranked_search returns valid_until and is deterministically ordered.
+--
+-- Background
+-- ----------
+-- Until V0011, ranked_search() did the 5-signal scoring in SQL but Java still did
+-- in-memory ranking via ReadToolService.search. Switching the Java path to call
+-- ranked_search() directly requires two SQL-side changes:
+--
+--   1. Extend the return shape with valid_until (consumed by Java result map).
+--   2. Add a stable ORDER BY id tiebreak so equal scores stay deterministic.
+--
+-- HNSW index on cells.embedding is intentionally NOT added here: V0008 dropped the
+-- fixed-dim constraint on the embedding column to allow embedding model swaps at
+-- runtime, and pgvector requires a fixed dimensionality at index build time. That
+-- index belongs in a dedicated migration once we re-pin the active embedding dim
+-- (or use a partial expression index with explicit cast).
+
+-- CREATE OR REPLACE cannot change RETURNS TABLE columns, so drop first.
+DROP FUNCTION IF EXISTS ranked_search(vector, TEXT, TEXT, TEXT, TEXT, INTEGER, REAL, REAL, REAL, REAL, REAL);
+
+CREATE FUNCTION ranked_search(
+    query_embedding vector,
+    query_text TEXT,
+    p_realm TEXT DEFAULT NULL,
+    p_signal TEXT DEFAULT NULL,
+    p_topic TEXT DEFAULT NULL,
+    p_limit INTEGER DEFAULT 10,
+    p_weight_semantic REAL DEFAULT 0.35,
+    p_weight_keyword REAL DEFAULT 0.15,
+    p_weight_recency REAL DEFAULT 0.20,
+    p_weight_importance REAL DEFAULT 0.15,
+    p_weight_popularity REAL DEFAULT 0.15
+)
+RETURNS TABLE (
+    id UUID, content TEXT, summary TEXT, realm TEXT, signal TEXT, topic TEXT,
+    tags TEXT[], importance SMALLINT, created_at TIMESTAMPTZ, valid_from TIMESTAMPTZ,
+    valid_until TIMESTAMPTZ,
+    score_semantic REAL, score_keyword REAL, score_recency REAL,
+    score_importance REAL, score_popularity REAL, score_total REAL
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH max_pop AS (
+        SELECT GREATEST(MAX(recent_access_count), 1)::REAL AS val FROM cell_popularity
+    ),
+    scored AS (
+        SELECT c.id, c.content, c.summary, c.realm, c.signal, c.topic,
+            c.tags, c.importance, c.created_at, c.valid_from, c.valid_until,
+            CASE WHEN c.embedding IS NOT NULL AND query_embedding IS NOT NULL
+                 THEN (1 - (c.embedding <=> query_embedding))::REAL ELSE 0::REAL END AS sem,
+            CASE WHEN query_text IS NOT NULL AND query_text != ''
+                 THEN LEAST(ts_rank_cd(c.tsv, plainto_tsquery('english', query_text))::REAL, 1.0::REAL)
+                 ELSE 0::REAL END AS kw,
+            EXP(-0.693 * EXTRACT(EPOCH FROM (now() - c.created_at)) / (90 * 86400))::REAL AS rec,
+            (CASE c.importance
+                WHEN 1 THEN 1.0 WHEN 2 THEN 0.8 WHEN 3 THEN 0.6
+                WHEN 4 THEN 0.4 WHEN 5 THEN 0.2 ELSE 0.6 END)::REAL AS imp,
+            COALESCE(cp.recent_access_count::REAL / (SELECT val FROM max_pop), 0)::REAL AS pop
+        FROM cells c
+        LEFT JOIN cell_popularity cp ON cp.cell_id = c.id
+        WHERE (c.valid_until IS NULL OR c.valid_until > now()) AND c.status = 'committed'
+          AND (p_realm IS NULL OR c.realm = p_realm)
+          AND (p_signal IS NULL OR c.signal = p_signal)
+          AND (p_topic IS NULL OR c.topic = p_topic)
+    )
+    SELECT s.id, s.content, s.summary, s.realm, s.signal, s.topic,
+           s.tags, s.importance, s.created_at, s.valid_from, s.valid_until,
+           s.sem, s.kw, s.rec, s.imp, s.pop,
+           (s.sem * p_weight_semantic + s.kw * p_weight_keyword +
+            s.rec * p_weight_recency + s.imp * p_weight_importance +
+            s.pop * p_weight_popularity)::REAL AS score_total
+    FROM scored s WHERE s.sem > 0.3 OR s.kw > 0
+    ORDER BY score_total DESC, s.id ASC LIMIT p_limit;
+END;
+$$ LANGUAGE plpgsql;

--- a/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
+++ b/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
@@ -38,7 +38,7 @@ class FlywayMigrationParityTest {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().info().pending()).isEmpty();
             assertThat(harness.dsl().fetchCount(DSL.table("migration_baseline"))).isEqualTo(1);
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(11);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(12);
         }
     }
 
@@ -46,7 +46,7 @@ class FlywayMigrationParityTest {
     void migrationsAreIdempotentOnSecondRun() throws SQLException {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().migrate().migrationsExecuted).isZero();
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(11);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(12);
         }
     }
 

--- a/java-server/src/test/java/com/hivemem/tools/read/ReadToolIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/read/ReadToolIntegrationTest.java
@@ -179,10 +179,15 @@ class ReadToolIntegrationTest {
         assertThat(results.get(0).path("score_total").isNumber()).isTrue();
         assertThat(results.get(0).path("score_semantic").isNumber()).isTrue();
         assertThat(results.get(0).path("score_keyword").isNumber()).isTrue();
-        assertThat(results).hasSize(2);
+        // plainto_tsquery uses AND semantics: only the cell containing both
+        // "semantic" and "oracle" matches. The "keyword oracle" cell lacks
+        // "semantic" and has no embedding, so the SQL hard filter excludes it.
+        assertThat(results).hasSize(1);
 
+        // Query "oracle" matches both cells; weighting favours importance, so
+        // the importance=1 cell ranks above the importance=5 cell.
         JsonNode weightedResults = callToolContent("hivemem_search", Map.of(
-                "query", "semantic oracle",
+                "query", "oracle",
                 "limit", 10,
                 "weight_semantic", 0.05,
                 "weight_keyword", 0.05,
@@ -190,6 +195,7 @@ class ReadToolIntegrationTest {
                 "weight_importance", 0.75,
                 "weight_popularity", 0.1
         ));
+        assertThat(weightedResults).hasSize(2);
         assertThat(weightedResults.get(0).path("id").asText()).isEqualTo("00000000-0000-0000-0000-000000000501");
     }
 

--- a/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
@@ -302,6 +302,70 @@ class SearchParityIntegrationTest {
         return values;
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // Tests added with V0012: SQL ranked_search now drives ReadToolService.search.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void hardFilterExcludesCellsWithNoSemanticOrKeywordMatch() throws Exception {
+        // Cell with no embedding and content that does not match the query at all.
+        // Old in-memory ranking always returned every candidate; the SQL function
+        // applies a hard filter (sem > 0.3 OR kw > 0), so this row must be absent.
+        insertDrawer(
+                UUID.fromString("00000000-0000-0000-0000-000000000901"),
+                "completely unrelated banana split",
+                "eng", "facts", "misc", 3, "unrelated", "committed",
+                OffsetDateTime.parse("2026-04-03T10:00:00Z")
+        );
+
+        JsonNode results = callTool("writer-token", "hivemem_search", Map.of(
+                "query", "kubernetes ingress",
+                "limit", 10
+        ));
+
+        assertThat(textValues(results, "id"))
+                .doesNotContain("00000000-0000-0000-0000-000000000901");
+    }
+
+    @Test
+    void deterministicTiebreakOrdersEqualScoresByIdAsc() throws Exception {
+        // Two cells with identical content, importance, and timestamps will produce
+        // identical scores. V0012 added an ORDER BY id ASC tiebreak so the order is
+        // stable across runs.
+        UUID lower = UUID.fromString("00000000-0000-0000-0000-000000000aa1");
+        UUID higher = UUID.fromString("00000000-0000-0000-0000-000000000aa2");
+        OffsetDateTime ts = OffsetDateTime.parse("2026-04-03T10:00:00Z");
+        insertDrawer(higher, "tiebreak probe text", "eng", "facts", "ord", 3, "probe", "committed", ts);
+        insertDrawer(lower, "tiebreak probe text", "eng", "facts", "ord", 3, "probe", "committed", ts);
+
+        JsonNode results = callTool("writer-token", "hivemem_search", Map.of(
+                "query", "tiebreak probe",
+                "limit", 10
+        ));
+
+        List<String> ids = textValues(results, "id");
+        assertThat(ids).startsWith(lower.toString(), higher.toString());
+    }
+
+    @Test
+    void validUntilIsExposedWhenIncluded() throws Exception {
+        insertDrawer(
+                UUID.fromString("00000000-0000-0000-0000-000000000bb1"),
+                "valid until probe content", "eng", "facts", "tmp", 3,
+                "valid until probe", "committed",
+                OffsetDateTime.parse("2026-04-03T10:00:00Z")
+        );
+
+        JsonNode results = callTool("writer-token", "hivemem_search", Map.of(
+                "query", "valid until probe",
+                "include", List.of("summary", "valid_from", "valid_until")
+        ));
+
+        assertThat(results).isNotEmpty();
+        assertThat(results.get(0).has("valid_until")).isTrue();
+        assertThat(results.get(0).path("valid_until").isNull()).isTrue();
+    }
+
     private void insertDrawer(
             UUID id,
             String content,


### PR DESCRIPTION
## Summary

- Wires `ReadToolService.search` to call the existing `ranked_search()` PL/pgSQL function via jOOQ instead of loading all candidate cells and scoring in-process.
- V0012 extends `ranked_search` to return `valid_until` and adds `ORDER BY score_total DESC, id ASC` for deterministic tie-break.
- Closes #45 (Slice A).

## Behavior changes (intentional, documented in tests)

| Aspect | Before (Java) | After (SQL function) |
|---|---|---|
| Keyword score | substring-token count | `ts_rank_cd(tsv, plainto_tsquery('english', q))` — AND semantics |
| Hard filter | none | `semantic > 0.3 OR keyword > 0` |
| Popularity column | `access_count` | `recent_access_count` |
| Tie-break | by id (Java) | by id (SQL) — now SQL-side |
| `valid_until` in result | yes | yes (added in V0012) |

## Out of scope (Slice B)

- HNSW index on `cells.embedding`: V0008 dropped the fixed-dim constraint to allow embedding-model swaps; pgvector needs fixed dim for HNSW. Belongs in a dedicated migration once the active dim is re-pinned (or via a partial expression index with explicit cast).
- Dictionary choice (`simple` vs `german+english`) for mixed DE/EN content.

## Test plan

- [x] `SearchParityIntegrationTest` (8 tests, 3 new): hard filter, deterministic tiebreak, `valid_until` exposure
- [x] `ReadToolIntegrationTest.searchToolReturnsRankedDrawerResults` updated for AND semantics
- [x] `FlywayMigrationParityTest` migration count bumped 11 → 12
- [x] Full Maven test suite: 305/305 passing