### PR TITLE
feat(search): switch tsv dictionary from 'english' to 'simple'

### DIFF
--- a/java-server/src/main/resources/db/migration/V0013__tsv_dictionary_simple.sql
+++ b/java-server/src/main/resources/db/migration/V0013__tsv_dictionary_simple.sql
@@ -1,0 +1,103 @@
+-- V0013: switch tsv dictionary from 'english' to 'simple'.
+--
+-- Background
+-- ----------
+-- HiveMem stores DE+EN mixed content (German user notes, English code/docs).
+-- The previous 'english' dictionary stemmed and stopword-filtered with English
+-- assumptions, so German queries lost matches and German stopwords like "der"/
+-- "die"/"das" leaked through as significant tokens.
+--
+-- The 'simple' dictionary lowercases and tokenizes by non-alphanumeric without
+-- stemming or stopword removal. Trade-off: English plurals no longer match the
+-- singular ("cells" != "cell"). Acceptable given the language mix.
+--
+-- The tsv column is GENERATED ALWAYS, so changing the expression requires a
+-- DROP COLUMN + ADD COLUMN cycle, which also drops the GIN index. We recreate
+-- both. ranked_search() must be updated in lockstep so plainto_tsquery uses the
+-- same dictionary.
+
+-- active_cells (and realm_stats which depends on it) SELECT *, so they pin the
+-- tsv column type. Drop them, swap the column, then recreate the views from
+-- the V0010 definitions.
+DROP VIEW IF EXISTS realm_stats;
+DROP VIEW IF EXISTS active_cells;
+
+ALTER TABLE cells DROP COLUMN tsv;
+ALTER TABLE cells ADD COLUMN tsv tsvector GENERATED ALWAYS AS (
+    setweight(to_tsvector('simple', coalesce(summary, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(content, '')), 'B')
+) STORED;
+CREATE INDEX IF NOT EXISTS idx_cells_tsv ON cells USING GIN (tsv);
+
+CREATE VIEW active_cells AS
+SELECT *
+FROM cells
+WHERE (valid_until IS NULL OR valid_until > now())
+  AND status = 'committed';
+
+CREATE VIEW realm_stats AS
+SELECT realm, topic, signal,
+       COUNT(*) AS cell_count,
+       MIN(created_at) AS first_entry,
+       MAX(created_at) AS last_entry
+FROM active_cells
+GROUP BY realm, topic, signal
+ORDER BY realm, topic, signal;
+
+DROP FUNCTION IF EXISTS ranked_search(vector, TEXT, TEXT, TEXT, TEXT, INTEGER, REAL, REAL, REAL, REAL, REAL);
+
+CREATE FUNCTION ranked_search(
+    query_embedding vector,
+    query_text TEXT,
+    p_realm TEXT DEFAULT NULL,
+    p_signal TEXT DEFAULT NULL,
+    p_topic TEXT DEFAULT NULL,
+    p_limit INTEGER DEFAULT 10,
+    p_weight_semantic REAL DEFAULT 0.35,
+    p_weight_keyword REAL DEFAULT 0.15,
+    p_weight_recency REAL DEFAULT 0.20,
+    p_weight_importance REAL DEFAULT 0.15,
+    p_weight_popularity REAL DEFAULT 0.15
+)
+RETURNS TABLE (
+    id UUID, content TEXT, summary TEXT, realm TEXT, signal TEXT, topic TEXT,
+    tags TEXT[], importance SMALLINT, created_at TIMESTAMPTZ, valid_from TIMESTAMPTZ,
+    valid_until TIMESTAMPTZ,
+    score_semantic REAL, score_keyword REAL, score_recency REAL,
+    score_importance REAL, score_popularity REAL, score_total REAL
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH max_pop AS (
+        SELECT GREATEST(MAX(recent_access_count), 1)::REAL AS val FROM cell_popularity
+    ),
+    scored AS (
+        SELECT c.id, c.content, c.summary, c.realm, c.signal, c.topic,
+            c.tags, c.importance, c.created_at, c.valid_from, c.valid_until,
+            CASE WHEN c.embedding IS NOT NULL AND query_embedding IS NOT NULL
+                 THEN (1 - (c.embedding <=> query_embedding))::REAL ELSE 0::REAL END AS sem,
+            CASE WHEN query_text IS NOT NULL AND query_text != ''
+                 THEN LEAST(ts_rank_cd(c.tsv, plainto_tsquery('simple', query_text))::REAL, 1.0::REAL)
+                 ELSE 0::REAL END AS kw,
+            EXP(-0.693 * EXTRACT(EPOCH FROM (now() - c.created_at)) / (90 * 86400))::REAL AS rec,
+            (CASE c.importance
+                WHEN 1 THEN 1.0 WHEN 2 THEN 0.8 WHEN 3 THEN 0.6
+                WHEN 4 THEN 0.4 WHEN 5 THEN 0.2 ELSE 0.6 END)::REAL AS imp,
+            COALESCE(cp.recent_access_count::REAL / (SELECT val FROM max_pop), 0)::REAL AS pop
+        FROM cells c
+        LEFT JOIN cell_popularity cp ON cp.cell_id = c.id
+        WHERE (c.valid_until IS NULL OR c.valid_until > now()) AND c.status = 'committed'
+          AND (p_realm IS NULL OR c.realm = p_realm)
+          AND (p_signal IS NULL OR c.signal = p_signal)
+          AND (p_topic IS NULL OR c.topic = p_topic)
+    )
+    SELECT s.id, s.content, s.summary, s.realm, s.signal, s.topic,
+           s.tags, s.importance, s.created_at, s.valid_from, s.valid_until,
+           s.sem, s.kw, s.rec, s.imp, s.pop,
+           (s.sem * p_weight_semantic + s.kw * p_weight_keyword +
+            s.rec * p_weight_recency + s.imp * p_weight_importance +
+            s.pop * p_weight_popularity)::REAL AS score_total
+    FROM scored s WHERE s.sem > 0.3 OR s.kw > 0
+    ORDER BY score_total DESC, s.id ASC LIMIT p_limit;
+END;
+$$ LANGUAGE plpgsql;

--- a/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
+++ b/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
@@ -38,7 +38,7 @@ class FlywayMigrationParityTest {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().info().pending()).isEmpty();
             assertThat(harness.dsl().fetchCount(DSL.table("migration_baseline"))).isEqualTo(1);
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(12);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(13);
         }
     }
 
@@ -46,7 +46,7 @@ class FlywayMigrationParityTest {
     void migrationsAreIdempotentOnSecondRun() throws SQLException {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().migrate().migrationsExecuted).isZero();
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(12);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(13);
         }
     }
 

--- a/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
@@ -348,6 +348,29 @@ class SearchParityIntegrationTest {
     }
 
     @Test
+    void germanContentIsMatchableAfterDictionarySwitch() throws Exception {
+        // V0013 switched the tsv dictionary from 'english' to 'simple' so German
+        // and English content tokenize equally (no English stemming/stopwords).
+        // The German word "Schlüsseldienst" (locksmith) would not have indexed
+        // sensibly under 'english'; under 'simple' it lowercases and matches.
+        insertDrawer(
+                UUID.fromString("00000000-0000-0000-0000-000000000cc1"),
+                "Notiz: Schlüsseldienst gerufen wegen ausgesperrter Mitarbeiterin",
+                "personal", "events", "haushalt", 3,
+                "Schlüsseldienst Einsatz", "committed",
+                OffsetDateTime.parse("2026-04-03T10:00:00Z")
+        );
+
+        JsonNode results = callTool("writer-token", "hivemem_search", Map.of(
+                "query", "Schlüsseldienst",
+                "limit", 10
+        ));
+
+        assertThat(textValues(results, "id"))
+                .contains("00000000-0000-0000-0000-000000000cc1");
+    }
+
+    @Test
     void validUntilIsExposedWhenIncluded() throws Exception {
         insertDrawer(
                 UUID.fromString("00000000-0000-0000-0000-000000000bb1"),


### PR DESCRIPTION
## Summary

Stacked on #47 (Slice A). Switches the `cells.tsv` generated column and `ranked_search()` from the `'english'` dictionary to `'simple'` so DE+EN mixed content tokenizes on equal footing.

## Why

The previous config applied English stemming and stopword removal. German stopwords leaked through as significant tokens, and queries with German words missed matches. `'simple'` just lowercases and tokenizes by non-alphanumeric — language-agnostic.

**Trade-off:** English plurals no longer match singulars (`cells` ≠ `cell`). Acceptable given the content mix; embedding similarity still covers conceptual matches.

## Migration mechanics

- `cells.tsv` is `GENERATED ALWAYS`, so changing the expression requires `DROP COLUMN` + `ADD COLUMN`.
- `active_cells` and `realm_stats` select `*` from `cells`, pinning the tsv type → migration drops and recreates them from the V0010 definitions.
- `ranked_search()` updated to `plainto_tsquery('simple', …)` in lockstep.

## Test plan

- [x] `SearchParityIntegrationTest.germanContentIsMatchableAfterDictionarySwitch` — German keyword match
- [x] `FlywayMigrationParityTest` count bumped 12 → 13
- [x] Full Maven test suite: 306/306 passing

## Out of scope

- HNSW index (still waiting on embedding-dim re-pin).

Closes #45 once both PRs land.