### PR TITLE
fix(embedding): ensure HNSW index exists on startup

### DIFF
--- a/java-server/src/main/java/com/hivemem/embedding/EmbeddingMigrationService.java
+++ b/java-server/src/main/java/com/hivemem/embedding/EmbeddingMigrationService.java
@@ -58,12 +58,18 @@ public class EmbeddingMigrationService implements ApplicationRunner {
             log.info("First run — saving embedding model info: model={}, dimension={}",
                     currentInfo.model(), currentInfo.dimension());
             stateRepository.saveInfo(currentInfo);
+            stateRepository.createEmbeddingIndex(currentInfo.dimension());
+            log.info("Created HNSW index for dimension {}", currentInfo.dimension());
             return;
         }
 
         EmbeddingInfo stored = storedInfo.get();
         if (stored.model().equals(currentInfo.model()) && stored.dimension() == currentInfo.dimension()) {
             log.info("Embedding model matches stored state. No reencoding needed.");
+            // Safety net: an operator who dropped the index manually or a pre-V0012
+            // deployment won't have one yet. CREATE INDEX IF NOT EXISTS is a no-op
+            // when the index already exists.
+            stateRepository.createEmbeddingIndex(currentInfo.dimension());
             return;
         }
 

--- a/java-server/src/test/java/com/hivemem/embedding/EmbeddingMigrationIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/embedding/EmbeddingMigrationIntegrationTest.java
@@ -100,6 +100,34 @@ class EmbeddingMigrationIntegrationTest {
     }
 
     @Test
+    void firstRunCreatesHnswIndexForActiveDimension() {
+        dslContext.execute("DROP INDEX IF EXISTS idx_cells_embedding");
+
+        embeddingMigrationService.run(null);
+
+        Integer count = dslContext.fetchOne(
+                "SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'cells' AND indexname = 'idx_cells_embedding'")
+                .get(0, Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void matchingModelStillEnsuresHnswIndexExists() {
+        // Simulate an older deployment where info is stored but the index was
+        // never created (first-run path predates this behavior, or an operator
+        // dropped it).
+        stateRepository.saveInfo(new EmbeddingInfo("test-model", 1024));
+        dslContext.execute("DROP INDEX IF EXISTS idx_cells_embedding");
+
+        embeddingMigrationService.run(null);
+
+        Integer count = dslContext.fetchOne(
+                "SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'cells' AND indexname = 'idx_cells_embedding'")
+                .get(0, Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
     void statusShowsNoReencodingWhenModelMatches() {
         assertThat(embeddingMigrationService.isReencodingActive()).isFalse();
         assertThat(embeddingMigrationService.getProgress()).isEmpty();


### PR DESCRIPTION
## Summary

Closes the gap noted in the 7.0.0 release notes: HNSW on \`cells.embedding\` is in fact supported via an expression index (\`(embedding::vector(N))\`) and \`EmbeddingMigrationService\` already creates it on model-swap. The missed edge cases:

1. **First-run** only persisted the model info — no index was created, so fresh deployments ran seq-scan forever.
2. **Matching-model path** skipped index creation, so a pre-V0012 deployment (or an operator who dropped the index) couldn't self-heal on restart.

Both paths now call \`createEmbeddingIndex(dimension)\`. \`CREATE INDEX IF NOT EXISTS\` makes steady-state restarts a no-op.

## Not in this PR

The planner still won't use the expression index from \`ranked_search()\` because the function queries \`c.embedding <=> query_embedding\` without the matching cast. That's a follow-up: either (a) regenerate the function body on startup with the dim baked in, or (b) switch to \`halfvec(4000)\` and re-pin the column.

## Test plan

- [x] New \`firstRunCreatesHnswIndexForActiveDimension\` — first run creates the index
- [x] New \`matchingModelStillEnsuresHnswIndexExists\` — dropped index is recreated on restart
- [x] Full Maven suite: 317/317 locally