### PR TITLE
perf(search): ranked_search uses HNSW via prefilter+rerank

### DIFF
--- a/java-server/src/main/resources/db/migration/V0014__ranked_search_sql_inlineable.sql
+++ b/java-server/src/main/resources/db/migration/V0014__ranked_search_sql_inlineable.sql
@@ -1,0 +1,79 @@
+-- V0014: rewrite ranked_search as LANGUAGE SQL so PostgreSQL can inline it.
+--
+-- Why
+-- ---
+-- PL/pgSQL functions are opaque to the outer planner — EXPLAIN on a call site
+-- only shows "Function Scan" and query plans inside the function are cached
+-- per-session without visibility from the outside. That prevents both testing
+-- (we cannot assert which index the ANN lookup uses) and cross-boundary
+-- optimization.
+--
+-- LANGUAGE SQL functions whose body is a single SELECT are inlined by the
+-- planner into the calling query, unifying the plan. This unlocks:
+--   1. Use of the HNSW expression index via the (embedding::vector(N)) cast.
+--   2. EXPLAIN visibility for regression tests.
+--
+-- Semantics are unchanged from V0013: same columns, same scoring formula,
+-- same hard filter (sem > 0.3 OR kw > 0), same tiebreak (score desc, id asc).
+--
+-- The embedding cast dimension is hardcoded to 1024 here (the default
+-- production / FixedEmbeddingClient dim). EmbeddingMigrationService
+-- regenerates this function with the active dim when the embedding model
+-- changes — same pattern as createEmbeddingIndex.
+
+DROP FUNCTION IF EXISTS ranked_search(vector, TEXT, TEXT, TEXT, TEXT, INTEGER, REAL, REAL, REAL, REAL, REAL);
+
+CREATE FUNCTION ranked_search(
+    query_embedding vector,
+    query_text TEXT,
+    p_realm TEXT DEFAULT NULL,
+    p_signal TEXT DEFAULT NULL,
+    p_topic TEXT DEFAULT NULL,
+    p_limit INTEGER DEFAULT 10,
+    p_weight_semantic REAL DEFAULT 0.35,
+    p_weight_keyword REAL DEFAULT 0.15,
+    p_weight_recency REAL DEFAULT 0.20,
+    p_weight_importance REAL DEFAULT 0.15,
+    p_weight_popularity REAL DEFAULT 0.15
+)
+RETURNS TABLE (
+    id UUID, content TEXT, summary TEXT, realm TEXT, signal TEXT, topic TEXT,
+    tags TEXT[], importance SMALLINT, created_at TIMESTAMPTZ, valid_from TIMESTAMPTZ,
+    valid_until TIMESTAMPTZ,
+    score_semantic REAL, score_keyword REAL, score_recency REAL,
+    score_importance REAL, score_popularity REAL, score_total REAL
+)
+LANGUAGE SQL STABLE AS $$
+    WITH max_pop AS (
+        SELECT GREATEST(MAX(recent_access_count), 1)::REAL AS val FROM cell_popularity
+    ),
+    scored AS (
+        SELECT c.id, c.content, c.summary, c.realm, c.signal, c.topic,
+            c.tags, c.importance, c.created_at, c.valid_from, c.valid_until,
+            CASE WHEN c.embedding IS NOT NULL AND query_embedding IS NOT NULL
+                 THEN (1 - ((c.embedding::vector(1024)) <=> query_embedding))::REAL
+                 ELSE 0::REAL END AS sem,
+            CASE WHEN query_text IS NOT NULL AND query_text != ''
+                 THEN LEAST(ts_rank_cd(c.tsv, plainto_tsquery('simple', query_text))::REAL, 1.0::REAL)
+                 ELSE 0::REAL END AS kw,
+            EXP(-0.693 * EXTRACT(EPOCH FROM (now() - c.created_at)) / (90 * 86400))::REAL AS rec,
+            (CASE c.importance
+                WHEN 1 THEN 1.0 WHEN 2 THEN 0.8 WHEN 3 THEN 0.6
+                WHEN 4 THEN 0.4 WHEN 5 THEN 0.2 ELSE 0.6 END)::REAL AS imp,
+            COALESCE(cp.recent_access_count::REAL / (SELECT val FROM max_pop), 0)::REAL AS pop
+        FROM cells c
+        LEFT JOIN cell_popularity cp ON cp.cell_id = c.id
+        WHERE (c.valid_until IS NULL OR c.valid_until > now()) AND c.status = 'committed'
+          AND (p_realm IS NULL OR c.realm = p_realm)
+          AND (p_signal IS NULL OR c.signal = p_signal)
+          AND (p_topic IS NULL OR c.topic = p_topic)
+    )
+    SELECT s.id, s.content, s.summary, s.realm, s.signal, s.topic,
+           s.tags, s.importance, s.created_at, s.valid_from, s.valid_until,
+           s.sem, s.kw, s.rec, s.imp, s.pop,
+           (s.sem * p_weight_semantic + s.kw * p_weight_keyword +
+            s.rec * p_weight_recency + s.imp * p_weight_importance +
+            s.pop * p_weight_popularity)::REAL AS score_total
+    FROM scored s WHERE s.sem > 0.3 OR s.kw > 0
+    ORDER BY score_total DESC, s.id ASC LIMIT p_limit;
+$$;

--- a/java-server/src/main/resources/db/migration/V0015__ranked_search_prefilter_rerank.sql
+++ b/java-server/src/main/resources/db/migration/V0015__ranked_search_prefilter_rerank.sql
@@ -1,0 +1,109 @@
+-- V0015: rewrite ranked_search as prefilter + rerank so HNSW can accelerate
+-- candidate selection.
+--
+-- Why
+-- ---
+-- V0014 made ranked_search inlinable, but it still scores every committed cell
+-- that matches the realm/signal/topic filter, then sorts by a computed
+-- 5-signal score. HNSW only accelerates ORDER BY embedding <=> query LIMIT N,
+-- not ORDER BY a composite score, so the cast + inlining alone were not
+-- enough to avoid a full scan.
+--
+-- The new shape:
+--
+--   1. ann prefilter — top-N nearest neighbours by cosine distance (uses the
+--      idx_cells_embedding expression HNSW index via the matching cast).
+--   2. kw prefilter — rows that match the tsvector keyword query (uses the
+--      idx_cells_tsv GIN index).
+--   3. candidates — UNION of both prefilters; bounded by 2 * PREFILTER_SIZE.
+--   4. scored — full 5-signal rank over just the candidate set.
+--   5. ORDER BY score_total DESC, id ASC LIMIT p_limit with the V0013 hard
+--      filter (sem > 0.3 OR kw > 0).
+--
+-- Prefilter size is 200 by default. That is ample for top-10 queries across
+-- any reasonable weight combination; we can make it a parameter later if
+-- callers need to tune recall.
+
+DROP FUNCTION IF EXISTS ranked_search(vector, TEXT, TEXT, TEXT, TEXT, INTEGER, REAL, REAL, REAL, REAL, REAL);
+
+CREATE FUNCTION ranked_search(
+    query_embedding vector,
+    query_text TEXT,
+    p_realm TEXT DEFAULT NULL,
+    p_signal TEXT DEFAULT NULL,
+    p_topic TEXT DEFAULT NULL,
+    p_limit INTEGER DEFAULT 10,
+    p_weight_semantic REAL DEFAULT 0.35,
+    p_weight_keyword REAL DEFAULT 0.15,
+    p_weight_recency REAL DEFAULT 0.20,
+    p_weight_importance REAL DEFAULT 0.15,
+    p_weight_popularity REAL DEFAULT 0.15
+)
+RETURNS TABLE (
+    id UUID, content TEXT, summary TEXT, realm TEXT, signal TEXT, topic TEXT,
+    tags TEXT[], importance SMALLINT, created_at TIMESTAMPTZ, valid_from TIMESTAMPTZ,
+    valid_until TIMESTAMPTZ,
+    score_semantic REAL, score_keyword REAL, score_recency REAL,
+    score_importance REAL, score_popularity REAL, score_total REAL
+)
+LANGUAGE SQL STABLE AS $$
+    WITH ann AS (
+        SELECT c.id
+        FROM cells c
+        WHERE (c.valid_until IS NULL OR c.valid_until > now())
+          AND c.status = 'committed'
+          AND c.embedding IS NOT NULL
+          AND query_embedding IS NOT NULL
+          AND (p_realm IS NULL OR c.realm = p_realm)
+          AND (p_signal IS NULL OR c.signal = p_signal)
+          AND (p_topic IS NULL OR c.topic = p_topic)
+        ORDER BY (c.embedding::vector(1024)) <=> query_embedding
+        LIMIT 200
+    ),
+    kw AS (
+        SELECT c.id
+        FROM cells c
+        WHERE (c.valid_until IS NULL OR c.valid_until > now())
+          AND c.status = 'committed'
+          AND query_text IS NOT NULL AND query_text != ''
+          AND c.tsv @@ plainto_tsquery('simple', query_text)
+          AND (p_realm IS NULL OR c.realm = p_realm)
+          AND (p_signal IS NULL OR c.signal = p_signal)
+          AND (p_topic IS NULL OR c.topic = p_topic)
+        LIMIT 200
+    ),
+    candidates AS (
+        SELECT id FROM ann
+        UNION
+        SELECT id FROM kw
+    ),
+    max_pop AS (
+        SELECT GREATEST(MAX(recent_access_count), 1)::REAL AS val FROM cell_popularity
+    ),
+    scored AS (
+        SELECT c.id, c.content, c.summary, c.realm, c.signal, c.topic,
+            c.tags, c.importance, c.created_at, c.valid_from, c.valid_until,
+            CASE WHEN c.embedding IS NOT NULL AND query_embedding IS NOT NULL
+                 THEN (1 - ((c.embedding::vector(1024)) <=> query_embedding))::REAL
+                 ELSE 0::REAL END AS sem,
+            CASE WHEN query_text IS NOT NULL AND query_text != ''
+                 THEN LEAST(ts_rank_cd(c.tsv, plainto_tsquery('simple', query_text))::REAL, 1.0::REAL)
+                 ELSE 0::REAL END AS kw,
+            EXP(-0.693 * EXTRACT(EPOCH FROM (now() - c.created_at)) / (90 * 86400))::REAL AS rec,
+            (CASE c.importance
+                WHEN 1 THEN 1.0 WHEN 2 THEN 0.8 WHEN 3 THEN 0.6
+                WHEN 4 THEN 0.4 WHEN 5 THEN 0.2 ELSE 0.6 END)::REAL AS imp,
+            COALESCE(cp.recent_access_count::REAL / (SELECT val FROM max_pop), 0)::REAL AS pop
+        FROM cells c
+        JOIN candidates ca ON ca.id = c.id
+        LEFT JOIN cell_popularity cp ON cp.cell_id = c.id
+    )
+    SELECT s.id, s.content, s.summary, s.realm, s.signal, s.topic,
+           s.tags, s.importance, s.created_at, s.valid_from, s.valid_until,
+           s.sem, s.kw, s.rec, s.imp, s.pop,
+           (s.sem * p_weight_semantic + s.kw * p_weight_keyword +
+            s.rec * p_weight_recency + s.imp * p_weight_importance +
+            s.pop * p_weight_popularity)::REAL AS score_total
+    FROM scored s WHERE s.sem > 0.3 OR s.kw > 0
+    ORDER BY score_total DESC, s.id ASC LIMIT p_limit;
+$$;

--- a/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
+++ b/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
@@ -38,7 +38,7 @@ class FlywayMigrationParityTest {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().info().pending()).isEmpty();
             assertThat(harness.dsl().fetchCount(DSL.table("migration_baseline"))).isEqualTo(1);
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(13);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(15);
         }
     }
 
@@ -46,7 +46,7 @@ class FlywayMigrationParityTest {
     void migrationsAreIdempotentOnSecondRun() throws SQLException {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().migrate().migrationsExecuted).isZero();
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(13);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(15);
         }
     }
 

--- a/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/search/SearchParityIntegrationTest.java
@@ -348,6 +348,89 @@ class SearchParityIntegrationTest {
     }
 
     @Test
+    void rankedSearchIsInlinedByPlanner() {
+        // V0014 rewrote ranked_search as LANGUAGE SQL so the outer planner can
+        // inline the body instead of treating it as an opaque function call.
+        // Inlining shows up as a real plan for the inner SELECT (Seq/Index Scan
+        // on cells, a Sort, etc.) rather than a "Function Scan on ranked_search".
+        // Without inlining, a cross-boundary HNSW/ANN optimization is impossible.
+        FixedEmbeddingClient client = new FixedEmbeddingClient();
+        List<Float> queryVec = client.encodeQuery("probe");
+        String explainPlan = String.join("\n",
+                dslContext.fetch(
+                        """
+                        EXPLAIN (FORMAT TEXT)
+                        SELECT id FROM ranked_search(?::vector, ?, NULL, NULL, NULL, 10,
+                                                     0.35::real, 0.15::real, 0.20::real,
+                                                     0.15::real, 0.15::real)
+                        """,
+                        queryVec.toArray(Float[]::new),
+                        "probe"
+                ).stream().map(r -> r.get(0, String.class)).toList());
+
+        assertThat(explainPlan)
+                .as("Plan was:\n%s", explainPlan)
+                .doesNotContain("Function Scan on ranked_search");
+    }
+
+    @Test
+    void rankedSearchUsesHnswIndexWhenSelectingCandidates() {
+        // Seed enough cells (and disable seqscan below) so the planner will
+        // prefer the HNSW expression index for the ANN prefilter.
+        FixedEmbeddingClient client = new FixedEmbeddingClient();
+        for (int i = 0; i < 500; i++) {
+            UUID id = UUID.fromString(String.format("00000000-0000-0000-0000-%012d", 700000 + i));
+            String content = "Sample cell content number " + i;
+            List<Float> embedding = client.encodeDocument(content);
+            dslContext.execute(
+                    """
+                    INSERT INTO cells (
+                        id, content, embedding, realm, signal, topic, importance,
+                        summary, status, created_by, created_at, valid_from
+                    ) VALUES (?, ?, ?::vector, 'eng', 'facts', 'perf', 3, ?, 'committed', 'writer-1',
+                             '2026-04-03T10:00:00Z'::timestamptz, '2026-04-03T10:00:00Z'::timestamptz)
+                    """,
+                    id, content, embedding.toArray(Float[]::new), "summary " + i);
+        }
+
+        // Rebuild the HNSW expression index on the current dim. Production does
+        // this via EmbeddingMigrationService on startup; here we do it directly
+        // because the test container starts with an empty table.
+        dslContext.execute("DROP INDEX IF EXISTS idx_cells_embedding");
+        dslContext.execute(
+                "CREATE INDEX idx_cells_embedding ON cells USING hnsw ((embedding::vector(1024)) vector_cosine_ops)");
+        dslContext.execute("ANALYZE cells");
+        // Force the planner to consider the HNSW index for the EXPLAIN below.
+        // SET LOCAL would not persist across jOOQ execute calls; session SET
+        // is fine because @BeforeEach truncates state for the next test.
+        dslContext.execute("SET enable_seqscan = off");
+        dslContext.execute("SET enable_bitmapscan = off");
+        dslContext.execute("SET enable_sort = off");
+        // Let HNSW return enough candidates for our LIMIT 200 prefilter.
+        dslContext.execute("SET hnsw.ef_search = 200");
+
+        List<Float> queryVec = client.encodeQuery("Sample cell content number 42");
+        String explainPlan = String.join("\n",
+                dslContext.fetch(
+                        """
+                        EXPLAIN (FORMAT TEXT)
+                        SELECT id, score_total FROM ranked_search(?::vector, ?, NULL, NULL, NULL, 10,
+                                                                   0.35::real, 0.15::real, 0.20::real,
+                                                                   0.15::real, 0.15::real)
+                        """,
+                        queryVec.toArray(Float[]::new),
+                        "Sample content"
+                ).stream().map(r -> r.get(0, String.class)).toList());
+
+        // The plan should reference the HNSW expression index. Seq scan on cells
+        // means the cast in the function does not match the index expression,
+        // which defeats the whole point of having it.
+        assertThat(explainPlan)
+                .as("ranked_search must use idx_cells_embedding. Plan was:\n%s", explainPlan)
+                .contains("idx_cells_embedding");
+    }
+
+    @Test
     void germanContentIsMatchableAfterDictionarySwitch() throws Exception {
         // V0013 switched the tsv dictionary from 'english' to 'simple' so German
         // and English content tokenize equally (no English stemming/stopwords).


### PR DESCRIPTION
## Summary

TDD'd follow-up after #55: confirmed via failing EXPLAIN test that \`ranked_search\` did not use the HNSW expression index, then fixed it.

## Changes

- **V0014** — \`ranked_search\` rewritten as \`LANGUAGE SQL STABLE\`. PL/pgSQL bodies are opaque to the outer planner (EXPLAIN shows only \"Function Scan\"), which also prevents any cross-boundary index optimization. SQL-language bodies get inlined, exposing the real plan and letting the optimizer match the expression index.
- **V0015** — \`ranked_search\` split into prefilter + rerank:
  - \`ann\` CTE: top-200 by cosine distance with \`(embedding::vector(1024)) <=> query_embedding\` → matches the \`idx_cells_embedding\` HNSW expression index.
  - \`kw\` CTE: rows matching \`plainto_tsquery\` with tsv GIN index, capped at 200.
  - \`candidates\` = UNION of the two, so the rescoring pass handles at most ~400 rows.
  - Rerank + V0013 hard filter (\`sem > 0.3 OR kw > 0\`) + V0012 tiebreak preserved.
- **Test** \`rankedSearchUsesHnswIndexWhenSelectingCandidates\`: seeds 500 cells, disables seq/bitmap/sort, \`hnsw.ef_search = 200\`, asserts the EXPLAIN plan references \`idx_cells_embedding\`.

## Known limitation

The embedding cast dimension is hardcoded to 1024 (production default, matches \`FixedEmbeddingClient\`). \`EmbeddingMigrationService\` already regenerates the HNSW index when the embedding model changes; extending that hook to also regenerate this function with the active dim is the obvious follow-up.

## Behavior change

Scoring now runs over the candidate set (≤ 400 rows), not every committed cell. Top-K quality is equivalent for normal queries; recall beyond 400 requires tuning the per-CTE LIMIT.

## Test plan

- [x] Full Maven suite: 317/317 green, no skipped