### PR TITLE
fix(search): dynamic embedding dimension for ranked_search

### DIFF
--- a/RELEASE_NOTES_7.1.1.md
+++ b/RELEASE_NOTES_7.1.1.md
@@ -1,0 +1,12 @@
+# HiveMem 7.1.1
+
+## Fixes
+
+- `ranked_search` SQL function is now created at startup by `EmbeddingMigrationService` with the active embedding dimension reported by the embedding service, instead of being hardcoded to `vector(1024)` in Flyway migrations V0014/V0015. Production deployments using non-default embedding models (e.g. `paraphrase-multilingual-MiniLM-L12-v2` at 384 dimensions) no longer fail every search call with `expected 1024 dimensions, not N`.
+
+## Internal
+
+- New SQL template `db/templates/ranked_search.sql.tmpl` with `{{DIM}}` placeholder.
+- New `RankedSearchTemplate` loader and `EmbeddingStateRepository.replaceRankedSearchFunction(int)`.
+- V0017 migration drops the previously Flyway-owned `ranked_search`; the service is now sole owner.
+- Function is recreated on every startup path (first-run, match, post-reencode), parallel to existing HNSW index handling.

--- a/java-server/src/main/java/com/hivemem/embedding/EmbeddingMigrationService.java
+++ b/java-server/src/main/java/com/hivemem/embedding/EmbeddingMigrationService.java
@@ -60,6 +60,7 @@ public class EmbeddingMigrationService implements ApplicationRunner {
             stateRepository.saveInfo(currentInfo);
             stateRepository.createEmbeddingIndex(currentInfo.dimension());
             log.info("Created HNSW index for dimension {}", currentInfo.dimension());
+            ensureRankedSearchFunction(currentInfo.dimension());
             return;
         }
 
@@ -70,6 +71,7 @@ public class EmbeddingMigrationService implements ApplicationRunner {
             // deployment won't have one yet. CREATE INDEX IF NOT EXISTS is a no-op
             // when the index already exists.
             stateRepository.createEmbeddingIndex(currentInfo.dimension());
+            ensureRankedSearchFunction(currentInfo.dimension());
             return;
         }
 
@@ -118,6 +120,7 @@ public class EmbeddingMigrationService implements ApplicationRunner {
 
             stateRepository.createEmbeddingIndex(to.dimension());
             log.info("Recreated HNSW index");
+            ensureRankedSearchFunction(to.dimension());
 
             stateRepository.saveInfo(to);
             stateRepository.clearProgress();
@@ -142,5 +145,10 @@ public class EmbeddingMigrationService implements ApplicationRunner {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Backup failed", e);
         }
+    }
+
+    private void ensureRankedSearchFunction(int dimension) {
+        stateRepository.replaceRankedSearchFunction(dimension);
+        log.info("Recreated ranked_search function for dimension {}", dimension);
     }
 }

--- a/java-server/src/main/java/com/hivemem/embedding/EmbeddingMigrationService.java
+++ b/java-server/src/main/java/com/hivemem/embedding/EmbeddingMigrationService.java
@@ -40,6 +40,10 @@ public class EmbeddingMigrationService implements ApplicationRunner {
         return stateRepository.loadProgress();
     }
 
+    public int getCurrentDimension() {
+        return embeddingClient.getInfo().dimension();
+    }
+
     @Override
     public void run(ApplicationArguments args) {
         EmbeddingInfo currentInfo;

--- a/java-server/src/main/java/com/hivemem/embedding/EmbeddingStateRepository.java
+++ b/java-server/src/main/java/com/hivemem/embedding/EmbeddingStateRepository.java
@@ -85,6 +85,11 @@ public class EmbeddingStateRepository {
                 "ON cells USING hnsw ((embedding::vector(" + dimension + ")) vector_cosine_ops)");
     }
 
+    public void replaceRankedSearchFunction(int dimension) {
+        String sql = RankedSearchTemplate.render(dimension);
+        dslContext.execute(sql);
+    }
+
     public boolean tryAdvisoryLock(long lockId) {
         Record row = dslContext.fetchOne("SELECT pg_try_advisory_lock(?) AS acquired", lockId);
         return row != null && Boolean.TRUE.equals(row.get("acquired", Boolean.class));

--- a/java-server/src/main/java/com/hivemem/embedding/RankedSearchTemplate.java
+++ b/java-server/src/main/java/com/hivemem/embedding/RankedSearchTemplate.java
@@ -1,0 +1,34 @@
+package com.hivemem.embedding;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+
+final class RankedSearchTemplate {
+
+    private static final String RESOURCE_PATH = "db/templates/ranked_search.sql.tmpl";
+    private static final String PLACEHOLDER = "{{DIM}}";
+
+    private RankedSearchTemplate() {
+    }
+
+    static String render(int dimension) {
+        if (dimension <= 0) {
+            throw new IllegalArgumentException("dimension must be positive, got " + dimension);
+        }
+        String template = load();
+        return template.replace(PLACEHOLDER, Integer.toString(dimension));
+    }
+
+    private static String load() {
+        try (InputStream in = new ClassPathResource(RESOURCE_PATH).getInputStream()) {
+            return StreamUtils.copyToString(in, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load " + RESOURCE_PATH, e);
+        }
+    }
+}

--- a/java-server/src/main/resources/db/migration/V0017__drop_ranked_search.sql
+++ b/java-server/src/main/resources/db/migration/V0017__drop_ranked_search.sql
@@ -1,0 +1,5 @@
+-- V0017: ranked_search is now managed by EmbeddingMigrationService so its
+-- vector(N) cast can be kept in sync with the active embedding dimension.
+-- Drop the Flyway-owned definition; the service recreates it on every startup.
+
+DROP FUNCTION IF EXISTS ranked_search(vector, TEXT, TEXT, TEXT, TEXT, INTEGER, REAL, REAL, REAL, REAL, REAL);

--- a/java-server/src/main/resources/db/templates/ranked_search.sql.tmpl
+++ b/java-server/src/main/resources/db/templates/ranked_search.sql.tmpl
@@ -1,0 +1,84 @@
+-- Template loaded by EmbeddingStateRepository.replaceRankedSearchFunction.
+-- {{DIM}} is replaced at runtime with the active embedding dimension.
+
+CREATE OR REPLACE FUNCTION ranked_search(
+    query_embedding vector,
+    query_text TEXT,
+    p_realm TEXT DEFAULT NULL,
+    p_signal TEXT DEFAULT NULL,
+    p_topic TEXT DEFAULT NULL,
+    p_limit INTEGER DEFAULT 10,
+    p_weight_semantic REAL DEFAULT 0.35,
+    p_weight_keyword REAL DEFAULT 0.15,
+    p_weight_recency REAL DEFAULT 0.20,
+    p_weight_importance REAL DEFAULT 0.15,
+    p_weight_popularity REAL DEFAULT 0.15
+)
+RETURNS TABLE (
+    id UUID, content TEXT, summary TEXT, realm TEXT, signal TEXT, topic TEXT,
+    tags TEXT[], importance SMALLINT, created_at TIMESTAMPTZ, valid_from TIMESTAMPTZ,
+    valid_until TIMESTAMPTZ,
+    score_semantic REAL, score_keyword REAL, score_recency REAL,
+    score_importance REAL, score_popularity REAL, score_total REAL
+)
+LANGUAGE SQL STABLE AS $$
+    WITH ann AS (
+        SELECT c.id
+        FROM cells c
+        WHERE (c.valid_until IS NULL OR c.valid_until > now())
+          AND c.status = 'committed'
+          AND c.embedding IS NOT NULL
+          AND query_embedding IS NOT NULL
+          AND (p_realm IS NULL OR c.realm = p_realm)
+          AND (p_signal IS NULL OR c.signal = p_signal)
+          AND (p_topic IS NULL OR c.topic = p_topic)
+        ORDER BY (c.embedding::vector({{DIM}})) <=> query_embedding
+        LIMIT 200
+    ),
+    kw AS (
+        SELECT c.id
+        FROM cells c
+        WHERE (c.valid_until IS NULL OR c.valid_until > now())
+          AND c.status = 'committed'
+          AND query_text IS NOT NULL AND query_text != ''
+          AND c.tsv @@ plainto_tsquery('simple', query_text)
+          AND (p_realm IS NULL OR c.realm = p_realm)
+          AND (p_signal IS NULL OR c.signal = p_signal)
+          AND (p_topic IS NULL OR c.topic = p_topic)
+        LIMIT 200
+    ),
+    candidates AS (
+        SELECT id FROM ann
+        UNION
+        SELECT id FROM kw
+    ),
+    max_pop AS (
+        SELECT GREATEST(MAX(recent_access_count), 1)::REAL AS val FROM cell_popularity
+    ),
+    scored AS (
+        SELECT c.id, c.content, c.summary, c.realm, c.signal, c.topic,
+            c.tags, c.importance, c.created_at, c.valid_from, c.valid_until,
+            CASE WHEN c.embedding IS NOT NULL AND query_embedding IS NOT NULL
+                 THEN (1 - ((c.embedding::vector({{DIM}})) <=> query_embedding))::REAL
+                 ELSE 0::REAL END AS sem,
+            CASE WHEN query_text IS NOT NULL AND query_text != ''
+                 THEN LEAST(ts_rank_cd(c.tsv, plainto_tsquery('simple', query_text))::REAL, 1.0::REAL)
+                 ELSE 0::REAL END AS kw,
+            EXP(-0.693 * EXTRACT(EPOCH FROM (now() - c.created_at)) / (90 * 86400))::REAL AS rec,
+            (CASE c.importance
+                WHEN 1 THEN 1.0 WHEN 2 THEN 0.8 WHEN 3 THEN 0.6
+                WHEN 4 THEN 0.4 WHEN 5 THEN 0.2 ELSE 0.6 END)::REAL AS imp,
+            COALESCE(cp.recent_access_count::REAL / (SELECT val FROM max_pop), 0)::REAL AS pop
+        FROM cells c
+        JOIN candidates ca ON ca.id = c.id
+        LEFT JOIN cell_popularity cp ON cp.cell_id = c.id
+    )
+    SELECT s.id, s.content, s.summary, s.realm, s.signal, s.topic,
+           s.tags, s.importance, s.created_at, s.valid_from, s.valid_until,
+           s.sem, s.kw, s.rec, s.imp, s.pop,
+           (s.sem * p_weight_semantic + s.kw * p_weight_keyword +
+            s.rec * p_weight_recency + s.imp * p_weight_importance +
+            s.pop * p_weight_popularity)::REAL AS score_total
+    FROM scored s WHERE s.sem > 0.3 OR s.kw > 0
+    ORDER BY score_total DESC, s.id ASC LIMIT p_limit;
+$$;

--- a/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
+++ b/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
@@ -38,7 +38,7 @@ class FlywayMigrationParityTest {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().info().pending()).isEmpty();
             assertThat(harness.dsl().fetchCount(DSL.table("migration_baseline"))).isEqualTo(1);
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(15);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(16);
         }
     }
 
@@ -46,7 +46,7 @@ class FlywayMigrationParityTest {
     void migrationsAreIdempotentOnSecondRun() throws SQLException {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().migrate().migrationsExecuted).isZero();
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(15);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(16);
         }
     }
 

--- a/java-server/src/test/java/com/hivemem/embedding/EmbeddingMigrationIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/embedding/EmbeddingMigrationIntegrationTest.java
@@ -261,6 +261,18 @@ class EmbeddingMigrationIntegrationTest {
         assertThat(result.get("cnt", Number.class).intValue()).isEqualTo(2);
     }
 
+    @Test
+    void rankedSearchFunctionExistsWithActiveDimension() {
+        int dim = embeddingMigrationService.getCurrentDimension();
+        Float[] zeros = new Float[dim];
+        java.util.Arrays.fill(zeros, 0.0f);
+
+        // Should not throw "expected N dimensions, not M".
+        dslContext.execute(
+                "SELECT * FROM ranked_search(?::vector, ?, NULL, NULL, NULL, 1, 0.35, 0.15, 0.20, 0.15, 0.15)",
+                zeros, "");
+    }
+
     private void insertDrawer(String content, String wing, String hall, String room) {
         FixedEmbeddingClient client = new FixedEmbeddingClient();
         var embedding = client.encodeDocument(content);

--- a/java-server/src/test/java/com/hivemem/embedding/RankedSearchTemplateTest.java
+++ b/java-server/src/test/java/com/hivemem/embedding/RankedSearchTemplateTest.java
@@ -1,0 +1,36 @@
+package com.hivemem.embedding;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RankedSearchTemplateTest {
+
+    @Test
+    void rendersTemplateWithGivenDimension() {
+        String sql = RankedSearchTemplate.render(384);
+
+        assertThat(sql).contains("vector(384)");
+        assertThat(sql).doesNotContain("{{DIM}}");
+        assertThat(sql).doesNotContain("vector(1024)");
+        assertThat(sql).contains("CREATE OR REPLACE FUNCTION ranked_search");
+    }
+
+    @Test
+    void rendersAllPlaceholderOccurrences() {
+        String sql = RankedSearchTemplate.render(768);
+
+        long count = sql.lines().filter(l -> l.contains("vector(768)")).count();
+        assertThat(count).isGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void rejectsNonPositiveDimension() {
+        org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> RankedSearchTemplate.render(0));
+        org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> RankedSearchTemplate.render(-1));
+    }
+}


### PR DESCRIPTION
## Summary
- Move `ranked_search` ownership from Flyway to `EmbeddingMigrationService` so the `vector(N)` cast tracks the active embedding dimension reported by the embedding service.
- Fixes prod regression: 7.1.0 + 384-dim embedding service yields `ERROR: expected 1024 dimensions, not 384` on every search.
- V0017 drops the Flyway-owned function; the service recreates it via `CREATE OR REPLACE FUNCTION` on every startup (first-run, match safety-net, post-reencode), parallel to the existing HNSW index handling.

## Test plan
- [x] Unit tests for the SQL template loader (3/3 pass)
- [x] Integration test asserts `ranked_search` is callable with the active dimension
- [x] Full Java test suite: 292 passed, 0 failures
- [ ] After deploy on CT 102, `mcp__hivemem__search` returns results without dimension error