### PR TITLE
feat: graph proximity (#25) + Claude Code hook (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ HiveMem is built on the premise that well-structured external knowledge systems 
 ## Features
 
 - **30 MCP tools** across search, knowledge graph, progressive summarization, agent fleet, references, and admin
-- **5-signal ranked search** -- semantic similarity + keyword match + recency + importance + popularity
+- **6-signal ranked search** -- semantic similarity + keyword match + recency + importance + popularity + graph proximity
 - **Append-only versioning** -- never lose history, revise with parent_id chains, point-in-time queries
 - **Progressive summarization** -- content, summary, key_points, insight per cell
 - **Temporal knowledge graph** -- facts with valid_from/valid_until, contradiction detection, multi-hop traversal
@@ -447,7 +447,7 @@ graph TB
 
 1. **Store** -- Content is classified into realm/signal/topic and stored as a cell with progressive summarization (content, summary, key points, insight)
 2. **Connect** -- Tunnels link related cells across the structure; facts capture atomic relationships in the knowledge graph
-3. **Search** -- 5-signal ranked search finds cells by meaning, keywords, recency, importance, and popularity
+3. **Search** -- 6-signal ranked search finds cells by meaning, keywords, recency, importance, popularity, and graph proximity
 4. **Traverse** -- Follow tunnels to discover hidden connections; use time machine to see what was known at any point
 5. **Wake up** -- Each session starts with identity context and critical facts, like navigating back to your knowledge and remembering where everything is
 
@@ -567,7 +567,7 @@ Every HiveMem tool is mapped to a specific role to ensure least privilege. Write
 
 | Category | Tools | Access Role | Data Flow | HITL Required? | Description |
 |---|---|---|---|---|---|
-| **Search** | `search`, `search_kg`, `quick_facts`, `time_machine` | `reader` | Read Only | No | 5-signal semantic & keyword search. |
+| **Search** | `search`, `search_kg`, `quick_facts`, `time_machine` | `reader` | Read Only | No | 6-signal semantic & keyword search. |
 | **Read** | `status`, `get_cell`, `list_realms`, `traverse`, `wake_up`, `get_blueprint`, `history` | `reader` | Read Only | No | Navigation and context retrieval. |
 | **Write** | `add_cell`, `kg_add`, `kg_invalidate`, `revise_cell`, `revise_fact`, `update_identity`, `update_blueprint` | `agent` | Propose Change | Yes (for Agents) | Append-only knowledge capture. |
 | **Tunnels** | `add_tunnel`, `remove_tunnel` | `agent` | Link Discovery | Yes | Cell-to-cell semantic linking. |
@@ -637,15 +637,18 @@ Every HiveMem tool is mapped to a specific role to ensure least privilege. Write
 
 ### Search Signals
 
-The `search` tool combines 5 signals with configurable weights:
+The `search` tool combines 6 signals with configurable weights:
 
 | Signal | Default Weight | Description |
 |---|---|---|
-| Semantic | 0.35 | Vector cosine similarity |
+| Semantic | 0.30 | Vector cosine similarity |
 | Keyword | 0.15 | PostgreSQL full-text search (tsvector, BM25-like) |
-| Recency | 0.20 | Exponential decay, 90-day half-life |
+| Recency | 0.15 | Exponential decay, 90-day half-life |
 | Importance | 0.15 | User/agent assigned 1-5 scale |
 | Popularity | 0.15 | Access frequency (materialized view) |
+| Graph proximity | 0.10 | Boost for cells reachable from the top semantic candidates via tunnels (depth ≤ 2). Per-relation weights default to `builds_on=1.0`, `refines=0.8`, `related_to=0.6`, `contradicts=0.4`. |
+
+Weights are configurable via `hivemem.search.weights` in `application.yml` and per-call via the MCP `search` arguments (`weight_semantic`, `weight_keyword`, `weight_recency`, `weight_importance`, `weight_popularity`, `weight_graph_proximity`).
 
 `search` defaults to `summary`, `tags`, `importance`, and `created_at` plus required identity fields (`id`, `realm`, `signal`, `topic`). `get_cell` defaults to `summary`, `key_points`, `insight`, `tags`, `importance`, `source`, and `created_at` plus the same required identity fields. Pass `include` to request a specific subset of optional fields, including `content`.
 

--- a/README.md
+++ b/README.md
@@ -709,6 +709,81 @@ hivemem-token info <name>
 - **Path traversal protection** -- file import restricted to `/data/imports` and `/tmp`
 - **Tool call enforcement** -- `tools/call` checked against role permissions, not just `tools/list` filtering
 
+## Claude Code Hook Integration (Optional)
+
+HiveMem ships a `POST /hooks/context` endpoint that Claude Code can call on every `UserPromptSubmit` event. The hook performs a 6-signal ranked search against the user's prompt and injects up to 3 cell summaries into the conversation as `additionalContext`. The agent can then drill down on demand via `hivemem_get_cell` using the IDs in the injected block.
+
+The hook is an **enhancement, not a replacement** for explicit `hivemem_search` / `hivemem_get_cell` tool calls. CLAUDE.md guidance still applies; the hook just removes the burden of remembering to search.
+
+### Setup
+
+1. Create a dedicated reader-role token:
+
+   ```bash
+   docker exec hivemem hivemem-token create claude-code-hook --role reader
+   # Copy the printed token value once — it is not shown again.
+   ```
+
+2. Export it where Claude Code can read it:
+
+   ```bash
+   export HIVEMEM_HOOK_TOKEN=<token>
+   ```
+
+3. Merge `examples/claude-code-hook/settings.json` into your `~/.claude/settings.json` (or your project's `.claude/settings.json`):
+
+   ```json
+   {
+     "hooks": {
+       "UserPromptSubmit": [
+         {
+           "hooks": [
+             {
+               "type": "http",
+               "url": "http://localhost:8421/hooks/context",
+               "timeout": 5,
+               "headers": {
+                 "Authorization": "Bearer $HIVEMEM_HOOK_TOKEN"
+               },
+               "allowedEnvVars": ["HIVEMEM_HOOK_TOKEN"]
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+4. Restart Claude Code. The hook is now active.
+
+### Behaviour
+
+- Trivial prompts (less than 4 words, meta-phrases like `"ok"`/`"weiter"`/`"thanks"`, pure code blocks, prompts prefixed with `!nomem`) skip the search entirely. Use `!mem <prompt>` to force injection on a prompt that would otherwise be skipped.
+- Within a single Claude Code session, the same cell is suppressed for 5 turns after it was injected, to prevent context bloat.
+- Injected blocks contain only L1 summaries and cell IDs — never full content. The agent fetches details on demand.
+- Internal failures (DB down, search error) collapse to an empty `additionalContext`. The hook never blocks the user's message.
+
+### Configuration
+
+Tunable in `application.yml`:
+
+```yaml
+hivemem:
+  hooks:
+    enabled: true
+    relevance-threshold: 0.65
+    max-cells: 3
+    dedup-window-turns: 5
+```
+
+### Disabling
+
+Remove the hook block from your `~/.claude/settings.json`, or set `hivemem.hooks.enabled: false` on the server.
+
+### Trade-offs
+
+Each hook call adds ~50-200ms before the LLM call and ~50-200 tokens to the context window, in exchange for context continuity without explicit retrieval. If your workflow rarely benefits from prior knowledge, leave it off.
+
 ## Backups
 
 The `hivemem-backup` script is included in the Docker image. It is also called automatically before embedding reencoding.

--- a/examples/claude-code-hook/settings.json
+++ b/examples/claude-code-hook/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:8421/hooks/context",
+            "timeout": 5,
+            "headers": {
+              "Authorization": "Bearer $HIVEMEM_HOOK_TOKEN"
+            },
+            "allowedEnvVars": ["HIVEMEM_HOOK_TOKEN"]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/java-server/src/main/java/com/hivemem/auth/AuthFilter.java
+++ b/java-server/src/main/java/com/hivemem/auth/AuthFilter.java
@@ -30,7 +30,7 @@ public class AuthFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String requestPath = request.getRequestURI().substring(request.getContextPath().length());
-        return !requestPath.startsWith("/mcp");
+        return !requestPath.startsWith("/mcp") && !requestPath.startsWith("/hooks");
     }
 
     @Override

--- a/java-server/src/main/java/com/hivemem/hooks/ContextFormatter.java
+++ b/java-server/src/main/java/com/hivemem/hooks/ContextFormatter.java
@@ -1,0 +1,31 @@
+package com.hivemem.hooks;
+
+import com.hivemem.search.CellSearchRepository.RankedRow;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ContextFormatter {
+
+    public String format(List<RankedRow> rows, int turn) {
+        if (rows == null || rows.isEmpty()) return "";
+        String body = rows.stream()
+                .map(r -> "- " + safeSummary(r) + " (id: " + r.id() + ")")
+                .collect(Collectors.joining("\n"));
+        return "<hivemem_context turn=\"" + turn + "\">\n"
+                + "Relevant (summaries only — use hivemem_get_cell for details):\n"
+                + body + "\n"
+                + "</hivemem_context>";
+    }
+
+    private String safeSummary(RankedRow r) {
+        if (r.summary() != null && !r.summary().isBlank()) return r.summary().strip();
+        if (r.content() != null) {
+            String collapsed = r.content().strip().replaceAll("\\s+", " ");
+            return collapsed.length() > 120 ? collapsed.substring(0, 120) : collapsed;
+        }
+        return "(no summary)";
+    }
+}

--- a/java-server/src/main/java/com/hivemem/hooks/HookContextRequest.java
+++ b/java-server/src/main/java/com/hivemem/hooks/HookContextRequest.java
@@ -1,0 +1,10 @@
+package com.hivemem.hooks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record HookContextRequest(
+        @JsonProperty("hook_event_name") String hook_event_name,
+        @JsonProperty("prompt") String prompt,
+        @JsonProperty("session_id") String session_id,
+        @JsonProperty("cwd") String cwd
+) {}

--- a/java-server/src/main/java/com/hivemem/hooks/HookContextResponse.java
+++ b/java-server/src/main/java/com/hivemem/hooks/HookContextResponse.java
@@ -1,0 +1,16 @@
+package com.hivemem.hooks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record HookContextResponse(
+        @JsonProperty("hookSpecificOutput") HookSpecificOutput hookSpecificOutput
+) {
+    public record HookSpecificOutput(
+            @JsonProperty("hookEventName") String hookEventName,
+            @JsonProperty("additionalContext") String additionalContext
+    ) {}
+
+    public static HookContextResponse of(String eventName, String additionalContext) {
+        return new HookContextResponse(new HookSpecificOutput(eventName, additionalContext));
+    }
+}

--- a/java-server/src/main/java/com/hivemem/hooks/HookContextService.java
+++ b/java-server/src/main/java/com/hivemem/hooks/HookContextService.java
@@ -1,0 +1,85 @@
+package com.hivemem.hooks;
+
+import com.hivemem.embedding.EmbeddingClient;
+import com.hivemem.search.CellSearchRepository;
+import com.hivemem.search.CellSearchRepository.RankedRow;
+import com.hivemem.search.SearchWeights;
+import com.hivemem.search.SearchWeightsProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+public class HookContextService {
+
+    private static final Logger log = LoggerFactory.getLogger(HookContextService.class);
+    private static final int SEARCH_LIMIT = 10;
+
+    private final CellSearchRepository searchRepository;
+    private final EmbeddingClient embeddingClient;
+    private final SkipHeuristics skipHeuristics;
+    private final SessionInjectionCache cache;
+    private final ContextFormatter formatter;
+    private final HookProperties props;
+    private final SearchWeightsProperties weightsProperties;
+
+    private final ConcurrentHashMap<String, AtomicInteger> turnCounters = new ConcurrentHashMap<>();
+
+    public HookContextService(
+            CellSearchRepository searchRepository,
+            EmbeddingClient embeddingClient,
+            SkipHeuristics skipHeuristics,
+            SessionInjectionCache cache,
+            ContextFormatter formatter,
+            HookProperties props,
+            SearchWeightsProperties weightsProperties
+    ) {
+        this.searchRepository = searchRepository;
+        this.embeddingClient = embeddingClient;
+        this.skipHeuristics = skipHeuristics;
+        this.cache = cache;
+        this.formatter = formatter;
+        this.props = props;
+        this.weightsProperties = weightsProperties;
+    }
+
+    public String contextFor(HookContextRequest req) {
+        if (!props.isEnabled()) return "";
+        if (req == null || req.prompt() == null) return "";
+        if (skipHeuristics.evaluate(req.prompt()).skip()) return "";
+
+        String sessionKey = req.session_id() == null ? "_" : req.session_id();
+        int turn = turnCounters
+                .computeIfAbsent(sessionKey, k -> new AtomicInteger())
+                .incrementAndGet();
+
+        List<RankedRow> rows;
+        try {
+            List<Float> queryVector = embeddingClient.encodeQuery(req.prompt());
+            SearchWeights w = weightsProperties.toSearchWeights();
+            rows = searchRepository.rankedSearch(
+                    queryVector, req.prompt(), null, null, null, SEARCH_LIMIT,
+                    w.semantic(), w.keyword(), w.recency(),
+                    w.importance(), w.popularity(), w.graphProximity());
+        } catch (RuntimeException e) {
+            log.warn("Hook search failed; returning empty context", e);
+            return "";
+        }
+
+        List<RankedRow> filtered = rows.stream()
+                .filter(r -> r.scoreTotal() >= props.getRelevanceThreshold())
+                .filter(r -> !cache.recentlyInjected(sessionKey, r.id(), turn))
+                .limit(props.getMaxCells())
+                .toList();
+
+        if (filtered.isEmpty()) return "";
+        for (RankedRow r : filtered) {
+            cache.recordInjection(sessionKey, r.id(), turn);
+        }
+        return formatter.format(filtered, turn);
+    }
+}

--- a/java-server/src/main/java/com/hivemem/hooks/HookProperties.java
+++ b/java-server/src/main/java/com/hivemem/hooks/HookProperties.java
@@ -1,0 +1,26 @@
+package com.hivemem.hooks;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "hivemem.hooks")
+public class HookProperties {
+
+    private boolean enabled = true;
+    private double relevanceThreshold = 0.65;
+    private int maxCells = 3;
+    private int dedupWindowTurns = 5;
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public double getRelevanceThreshold() { return relevanceThreshold; }
+    public void setRelevanceThreshold(double v) { this.relevanceThreshold = v; }
+
+    public int getMaxCells() { return maxCells; }
+    public void setMaxCells(int v) { this.maxCells = v; }
+
+    public int getDedupWindowTurns() { return dedupWindowTurns; }
+    public void setDedupWindowTurns(int v) { this.dedupWindowTurns = v; }
+}

--- a/java-server/src/main/java/com/hivemem/hooks/HooksController.java
+++ b/java-server/src/main/java/com/hivemem/hooks/HooksController.java
@@ -22,6 +22,10 @@ public class HooksController {
 
     @PostMapping("/context")
     public ResponseEntity<HookContextResponse> context(@RequestBody HookContextRequest req) {
+        log.info("HOOK_CALL session={} event={} promptLen={}",
+                req == null ? "?" : req.session_id(),
+                req == null ? "?" : req.hook_event_name(),
+                req == null || req.prompt() == null ? 0 : req.prompt().length());
         String additional;
         try {
             additional = service.contextFor(req);

--- a/java-server/src/main/java/com/hivemem/hooks/HooksController.java
+++ b/java-server/src/main/java/com/hivemem/hooks/HooksController.java
@@ -1,0 +1,36 @@
+package com.hivemem.hooks;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/hooks")
+public class HooksController {
+
+    private static final Logger log = LoggerFactory.getLogger(HooksController.class);
+
+    private final HookContextService service;
+
+    public HooksController(HookContextService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/context")
+    public ResponseEntity<HookContextResponse> context(@RequestBody HookContextRequest req) {
+        String additional;
+        try {
+            additional = service.contextFor(req);
+        } catch (RuntimeException e) {
+            log.warn("Hook context failed; returning empty injection", e);
+            additional = "";
+        }
+        String eventName = req != null && req.hook_event_name() != null
+                ? req.hook_event_name() : "UserPromptSubmit";
+        return ResponseEntity.ok(HookContextResponse.of(eventName, additional));
+    }
+}

--- a/java-server/src/main/java/com/hivemem/hooks/SessionInjectionCache.java
+++ b/java-server/src/main/java/com/hivemem/hooks/SessionInjectionCache.java
@@ -1,0 +1,38 @@
+package com.hivemem.hooks;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Component
+public class SessionInjectionCache {
+
+    private record Key(String sessionId, UUID cellId) {}
+
+    private final Cache<Key, Integer> cache;
+    private final int dedupWindowTurns;
+
+    public SessionInjectionCache(Duration ttl, int dedupWindowTurns) {
+        this.dedupWindowTurns = dedupWindowTurns;
+        this.cache = Caffeine.newBuilder()
+                .expireAfterWrite(ttl)
+                .maximumSize(50_000)
+                .build();
+    }
+
+    public SessionInjectionCache() {
+        this(Duration.ofHours(1), 5);
+    }
+
+    public void recordInjection(String sessionId, UUID cellId, int turn) {
+        cache.put(new Key(sessionId, cellId), turn);
+    }
+
+    public boolean recentlyInjected(String sessionId, UUID cellId, int currentTurn) {
+        Integer recordedTurn = cache.getIfPresent(new Key(sessionId, cellId));
+        return recordedTurn != null && (currentTurn - recordedTurn) < dedupWindowTurns;
+    }
+}

--- a/java-server/src/main/java/com/hivemem/hooks/SkipHeuristics.java
+++ b/java-server/src/main/java/com/hivemem/hooks/SkipHeuristics.java
@@ -1,0 +1,34 @@
+package com.hivemem.hooks;
+
+import java.util.Set;
+
+public class SkipHeuristics {
+
+    public record SkipDecision(boolean skip, String reason) {
+        public static SkipDecision skip(String reason) { return new SkipDecision(true, reason); }
+        public static SkipDecision keep() { return new SkipDecision(false, ""); }
+    }
+
+    private static final Set<String> META_PHRASES = Set.of(
+            "ok", "okay", "yes", "no", "thanks", "thank you", "continue", "go on",
+            "try again", "make it shorter", "weiter", "danke", "ja", "nein"
+    );
+
+    public SkipDecision evaluate(String prompt) {
+        if (prompt == null) return SkipDecision.skip("null");
+        String trimmed = prompt.trim();
+        if (trimmed.isEmpty()) return SkipDecision.skip("empty");
+        String lower = trimmed.toLowerCase();
+        if (lower.startsWith("!nomem")) return SkipDecision.skip("opt_out");
+        if (lower.startsWith("!mem ")) return SkipDecision.keep();
+        if (META_PHRASES.contains(lower)) return SkipDecision.skip("meta");
+        if (isPureCodeBlock(trimmed)) return SkipDecision.skip("code_only");
+        long words = trimmed.split("\\s+").length;
+        if (words < 4) return SkipDecision.skip("too_short");
+        return SkipDecision.keep();
+    }
+
+    private boolean isPureCodeBlock(String s) {
+        return s.startsWith("```") && s.endsWith("```");
+    }
+}

--- a/java-server/src/main/java/com/hivemem/hooks/SkipHeuristics.java
+++ b/java-server/src/main/java/com/hivemem/hooks/SkipHeuristics.java
@@ -1,7 +1,10 @@
 package com.hivemem.hooks;
 
+import org.springframework.stereotype.Component;
+
 import java.util.Set;
 
+@Component
 public class SkipHeuristics {
 
     public record SkipDecision(boolean skip, String reason) {

--- a/java-server/src/main/java/com/hivemem/search/CellSearchRepository.java
+++ b/java-server/src/main/java/com/hivemem/search/CellSearchRepository.java
@@ -38,31 +38,27 @@ public class CellSearchRepository {
             double weightKeyword,
             double weightRecency,
             double weightImportance,
-            double weightPopularity
+            double weightPopularity,
+            double weightGraphProximity
     ) {
         Float[] embeddingArray = queryEmbedding == null ? null : queryEmbedding.toArray(Float[]::new);
         String sql = """
                 SELECT id, content, summary, realm, signal, topic, tags, importance,
                        created_at, valid_from, valid_until,
                        score_semantic, score_keyword, score_recency,
-                       score_importance, score_popularity, score_total
-                FROM ranked_search(?::vector, ?, ?, ?, ?, ?, ?::real, ?::real, ?::real, ?::real, ?::real)
+                       score_importance, score_popularity, score_graph_proximity,
+                       score_total
+                FROM ranked_search(?::vector, ?, ?, ?, ?, ?,
+                                   ?::real, ?::real, ?::real, ?::real, ?::real, ?::real)
                 """;
 
         List<RankedRow> rows = new ArrayList<>();
         for (Record row : dslContext.fetch(
                 sql,
-                embeddingArray,
-                queryText,
-                realm,
-                signal,
-                topic,
-                limit,
-                (float) weightSemantic,
-                (float) weightKeyword,
-                (float) weightRecency,
-                (float) weightImportance,
-                (float) weightPopularity
+                embeddingArray, queryText, realm, signal, topic, limit,
+                (float) weightSemantic, (float) weightKeyword, (float) weightRecency,
+                (float) weightImportance, (float) weightPopularity,
+                (float) weightGraphProximity
         )) {
             rows.add(new RankedRow(
                     row.get("id", UUID.class),
@@ -81,6 +77,7 @@ public class CellSearchRepository {
                     doubleValue(row, "score_recency"),
                     doubleValue(row, "score_importance"),
                     doubleValue(row, "score_popularity"),
+                    doubleValue(row, "score_graph_proximity"),
                     doubleValue(row, "score_total")
             ));
         }
@@ -104,6 +101,7 @@ public class CellSearchRepository {
             double scoreRecency,
             double scoreImportance,
             double scorePopularity,
+            double scoreGraphProximity,
             double scoreTotal
     ) {
     }

--- a/java-server/src/main/java/com/hivemem/search/SearchWeights.java
+++ b/java-server/src/main/java/com/hivemem/search/SearchWeights.java
@@ -1,0 +1,14 @@
+package com.hivemem.search;
+
+public record SearchWeights(
+        double semantic,
+        double keyword,
+        double recency,
+        double importance,
+        double popularity,
+        double graphProximity
+) {
+    public static SearchWeights defaults() {
+        return new SearchWeights(0.30, 0.15, 0.15, 0.15, 0.15, 0.10);
+    }
+}

--- a/java-server/src/main/java/com/hivemem/search/SearchWeightsProperties.java
+++ b/java-server/src/main/java/com/hivemem/search/SearchWeightsProperties.java
@@ -1,0 +1,38 @@
+package com.hivemem.search;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "hivemem.search.weights")
+public class SearchWeightsProperties {
+
+    private double semantic = 0.30;
+    private double keyword = 0.15;
+    private double recency = 0.15;
+    private double importance = 0.15;
+    private double popularity = 0.15;
+    private double graphProximity = 0.10;
+
+    public SearchWeights toSearchWeights() {
+        return new SearchWeights(semantic, keyword, recency, importance, popularity, graphProximity);
+    }
+
+    public double getSemantic() { return semantic; }
+    public void setSemantic(double v) { this.semantic = v; }
+
+    public double getKeyword() { return keyword; }
+    public void setKeyword(double v) { this.keyword = v; }
+
+    public double getRecency() { return recency; }
+    public void setRecency(double v) { this.recency = v; }
+
+    public double getImportance() { return importance; }
+    public void setImportance(double v) { this.importance = v; }
+
+    public double getPopularity() { return popularity; }
+    public void setPopularity(double v) { this.popularity = v; }
+
+    public double getGraphProximity() { return graphProximity; }
+    public void setGraphProximity(double v) { this.graphProximity = v; }
+}

--- a/java-server/src/main/java/com/hivemem/tools/read/ReadToolService.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/ReadToolService.java
@@ -5,6 +5,8 @@ import com.hivemem.cells.CellReadRepository;
 import com.hivemem.embedding.EmbeddingClient;
 import com.hivemem.search.CellSearchRepository;
 import com.hivemem.search.KgSearchRepository;
+import com.hivemem.search.SearchWeights;
+import com.hivemem.search.SearchWeightsProperties;
 import com.hivemem.write.AdminToolService;
 import org.springframework.stereotype.Service;
 
@@ -23,19 +25,22 @@ public class ReadToolService {
     private final CellSearchRepository cellSearchRepository;
     private final EmbeddingClient embeddingClient;
     private final AdminToolService adminToolService;
+    private final SearchWeightsProperties searchWeightsProperties;
 
     public ReadToolService(
             CellReadRepository cellReadRepository,
             KgSearchRepository kgSearchRepository,
             CellSearchRepository cellSearchRepository,
             EmbeddingClient embeddingClient,
-            AdminToolService adminToolService
+            AdminToolService adminToolService,
+            SearchWeightsProperties searchWeightsProperties
     ) {
         this.cellReadRepository = cellReadRepository;
         this.kgSearchRepository = kgSearchRepository;
         this.cellSearchRepository = cellSearchRepository;
         this.embeddingClient = embeddingClient;
         this.adminToolService = adminToolService;
+        this.searchWeightsProperties = searchWeightsProperties;
     }
 
     public Map<String, Object> status() {
@@ -72,10 +77,11 @@ public class ReadToolService {
             double weightPopularity
     ) {
         List<Float> queryVector = embeddingClient.encodeQuery(query);
+        SearchWeights weights = searchWeightsProperties.toSearchWeights();
         List<CellSearchRepository.RankedRow> rows = cellSearchRepository.rankedSearch(
                 queryVector, query, realm, signal, topic, limit,
                 weightSemantic, weightKeyword, weightRecency, weightImportance, weightPopularity,
-                0.10
+                weights.graphProximity()
         );
         return rows.stream().map(row -> projectRow(row, selection)).toList();
     }

--- a/java-server/src/main/java/com/hivemem/tools/read/ReadToolService.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/ReadToolService.java
@@ -5,7 +5,6 @@ import com.hivemem.cells.CellReadRepository;
 import com.hivemem.embedding.EmbeddingClient;
 import com.hivemem.search.CellSearchRepository;
 import com.hivemem.search.KgSearchRepository;
-import com.hivemem.search.SearchWeights;
 import com.hivemem.search.SearchWeightsProperties;
 import com.hivemem.write.AdminToolService;
 import org.springframework.stereotype.Service;
@@ -74,14 +73,14 @@ public class ReadToolService {
             double weightKeyword,
             double weightRecency,
             double weightImportance,
-            double weightPopularity
+            double weightPopularity,
+            double weightGraphProximity
     ) {
         List<Float> queryVector = embeddingClient.encodeQuery(query);
-        SearchWeights weights = searchWeightsProperties.toSearchWeights();
         List<CellSearchRepository.RankedRow> rows = cellSearchRepository.rankedSearch(
                 queryVector, query, realm, signal, topic, limit,
                 weightSemantic, weightKeyword, weightRecency, weightImportance, weightPopularity,
-                weights.graphProximity()
+                weightGraphProximity
         );
         return rows.stream().map(row -> projectRow(row, selection)).toList();
     }

--- a/java-server/src/main/java/com/hivemem/tools/read/ReadToolService.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/ReadToolService.java
@@ -74,7 +74,8 @@ public class ReadToolService {
         List<Float> queryVector = embeddingClient.encodeQuery(query);
         List<CellSearchRepository.RankedRow> rows = cellSearchRepository.rankedSearch(
                 queryVector, query, realm, signal, topic, limit,
-                weightSemantic, weightKeyword, weightRecency, weightImportance, weightPopularity
+                weightSemantic, weightKeyword, weightRecency, weightImportance, weightPopularity,
+                0.10
         );
         return rows.stream().map(row -> projectRow(row, selection)).toList();
     }

--- a/java-server/src/main/java/com/hivemem/tools/read/SearchToolHandler.java
+++ b/java-server/src/main/java/com/hivemem/tools/read/SearchToolHandler.java
@@ -44,11 +44,12 @@ public class SearchToolHandler implements ToolHandler {
                 .optionalString("signal", "Restrict search to this signal")
                 .optionalString("topic", "Restrict search to this topic")
                 .optionalEnumStringList("include", "Optional fields to return. Defaults to summary, tags, importance, created_at.", INCLUDE_FIELDS)
-                .optionalNumber("weight_semantic", "Semantic similarity weight (default 0.35)")
+                .optionalNumber("weight_semantic", "Semantic similarity weight (default 0.30)")
                 .optionalNumber("weight_keyword", "Keyword match weight (default 0.15)")
-                .optionalNumber("weight_recency", "Recency weight (default 0.20)")
+                .optionalNumber("weight_recency", "Recency weight (default 0.15)")
                 .optionalNumber("weight_importance", "Importance weight (default 0.15)")
                 .optionalNumber("weight_popularity", "Popularity weight (default 0.15)")
+                .optionalNumber("weight_graph_proximity", "Graph proximity weight (default 0.10)")
                 .build();
     }
 
@@ -60,11 +61,12 @@ public class SearchToolHandler implements ToolHandler {
         String signal = WriteArgumentParser.optionalText(arguments, "signal");
         String topic = WriteArgumentParser.optionalText(arguments, "topic");
         CellFieldSelection selection = CellFieldSelection.forSearch(CellFieldSelection.parseInclude(arguments));
-        double weightSemantic = optionalWeight(arguments, "weight_semantic", 0.35d);
+        double weightSemantic = optionalWeight(arguments, "weight_semantic", 0.30d);
         double weightKeyword = optionalWeight(arguments, "weight_keyword", 0.15d);
-        double weightRecency = optionalWeight(arguments, "weight_recency", 0.20d);
+        double weightRecency = optionalWeight(arguments, "weight_recency", 0.15d);
         double weightImportance = optionalWeight(arguments, "weight_importance", 0.15d);
         double weightPopularity = optionalWeight(arguments, "weight_popularity", 0.15d);
+        double weightGraphProximity = optionalWeight(arguments, "weight_graph_proximity", 0.10d);
         return readToolService.search(
                 query,
                 limit,
@@ -76,7 +78,8 @@ public class SearchToolHandler implements ToolHandler {
                 weightKeyword,
                 weightRecency,
                 weightImportance,
-                weightPopularity
+                weightPopularity,
+                weightGraphProximity
         );
     }
 

--- a/java-server/src/main/java/com/hivemem/web/SessionAuthFilter.java
+++ b/java-server/src/main/java/com/hivemem/web/SessionAuthFilter.java
@@ -40,6 +40,7 @@ public class SessionAuthFilter extends OncePerRequestFilter {
             FilterChain filterChain) throws ServletException, IOException {
         String path = request.getRequestURI().substring(request.getContextPath().length());
         boolean isMcp = path.startsWith("/mcp");
+        boolean isHooks = path.startsWith("/hooks");
         boolean isApi = path.startsWith("/api/");
 
         HttpSession session = request.getSession(false);
@@ -56,7 +57,7 @@ public class SessionAuthFilter extends OncePerRequestFilter {
             }
         }
 
-        if (isMcp) {
+        if (isMcp || isHooks) {
             filterChain.doFilter(request, response);
         } else if (isApi) {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED);

--- a/java-server/src/main/resources/application.yml
+++ b/java-server/src/main/resources/application.yml
@@ -20,6 +20,14 @@ hivemem:
     timeout: ${HIVEMEM_EMBEDDING_TIMEOUT:PT5S}
   popularity:
     refresh-interval: ${HIVEMEM_POPULARITY_REFRESH_INTERVAL:PT1H}
+  search:
+    weights:
+      semantic: 0.30
+      keyword: 0.15
+      recency: 0.15
+      importance: 0.15
+      popularity: 0.15
+      graph-proximity: 0.10
 
 server:
   port: ${SERVER_PORT:8421}

--- a/java-server/src/main/resources/application.yml
+++ b/java-server/src/main/resources/application.yml
@@ -28,6 +28,11 @@ hivemem:
       importance: 0.15
       popularity: 0.15
       graph-proximity: 0.10
+  hooks:
+    enabled: true
+    relevance-threshold: 0.65
+    max-cells: 3
+    dedup-window-turns: 5
 
 server:
   port: ${SERVER_PORT:8421}

--- a/java-server/src/main/resources/db/migration/V0018__graph_proximity.sql
+++ b/java-server/src/main/resources/db/migration/V0018__graph_proximity.sql
@@ -1,0 +1,34 @@
+-- Issue #25: graph proximity as 6th search signal.
+-- Returns one row per neighbour of any anchor in `anchors`, with an aggregated
+-- score = max over paths of (relation_weight * (1 / depth)). Anchors themselves
+-- are excluded so they don't double-count against their own ranking signal.
+
+CREATE OR REPLACE FUNCTION graph_proximity_scores(
+    anchors UUID[],
+    relation_weights JSONB,
+    max_depth INT DEFAULT 2
+)
+RETURNS TABLE (cell_id UUID, score REAL)
+LANGUAGE SQL STABLE AS $$
+    WITH RECURSIVE walk(cell_id, depth, path_score) AS (
+        SELECT a, 0, 1.0::REAL
+        FROM unnest(anchors) AS a
+        UNION ALL
+        SELECT t.to_cell,
+               w.depth + 1,
+               (w.path_score
+                 * COALESCE((relation_weights ->> t.relation)::REAL, 0.0::REAL)
+                 * (1.0::REAL / (w.depth + 1)))::REAL
+        FROM walk w
+        JOIN tunnels t
+          ON t.from_cell = w.cell_id
+         AND t.status = 'committed'
+         AND (t.valid_until IS NULL OR t.valid_until > now())
+        WHERE w.depth < max_depth
+    )
+    SELECT cell_id, MAX(path_score)::REAL AS score
+    FROM walk
+    WHERE depth > 0                          -- exclude anchors
+      AND NOT (cell_id = ANY(anchors))       -- never boost an anchor
+    GROUP BY cell_id;
+$$;

--- a/java-server/src/main/resources/db/templates/ranked_search.sql.tmpl
+++ b/java-server/src/main/resources/db/templates/ranked_search.sql.tmpl
@@ -8,18 +8,23 @@ CREATE OR REPLACE FUNCTION ranked_search(
     p_signal TEXT DEFAULT NULL,
     p_topic TEXT DEFAULT NULL,
     p_limit INTEGER DEFAULT 10,
-    p_weight_semantic REAL DEFAULT 0.35,
+    p_weight_semantic REAL DEFAULT 0.30,
     p_weight_keyword REAL DEFAULT 0.15,
-    p_weight_recency REAL DEFAULT 0.20,
+    p_weight_recency REAL DEFAULT 0.15,
     p_weight_importance REAL DEFAULT 0.15,
-    p_weight_popularity REAL DEFAULT 0.15
+    p_weight_popularity REAL DEFAULT 0.15,
+    p_weight_graph_proximity REAL DEFAULT 0.10,
+    p_relation_weights JSONB DEFAULT
+        '{"builds_on":1.0,"refines":0.8,"related_to":0.6,"contradicts":0.4}'::jsonb,
+    p_graph_max_depth INT DEFAULT 2
 )
 RETURNS TABLE (
     id UUID, content TEXT, summary TEXT, realm TEXT, signal TEXT, topic TEXT,
     tags TEXT[], importance SMALLINT, created_at TIMESTAMPTZ, valid_from TIMESTAMPTZ,
     valid_until TIMESTAMPTZ,
     score_semantic REAL, score_keyword REAL, score_recency REAL,
-    score_importance REAL, score_popularity REAL, score_total REAL
+    score_importance REAL, score_popularity REAL, score_graph_proximity REAL,
+    score_total REAL
 )
 LANGUAGE SQL STABLE AS $$
     WITH ann AS (
@@ -52,6 +57,22 @@ LANGUAGE SQL STABLE AS $$
         UNION
         SELECT id FROM kw
     ),
+    anchors AS (
+        SELECT c.id
+        FROM cells c
+        JOIN candidates ca ON ca.id = c.id
+        WHERE c.embedding IS NOT NULL AND query_embedding IS NOT NULL
+        ORDER BY (c.embedding::vector({{DIM}})) <=> query_embedding
+        LIMIT 25
+    ),
+    graph AS (
+        SELECT cell_id, score
+        FROM graph_proximity_scores(
+            (SELECT array_agg(id) FROM anchors),
+            p_relation_weights,
+            p_graph_max_depth
+        )
+    ),
     max_pop AS (
         SELECT GREATEST(MAX(recent_access_count), 1)::REAL AS val FROM cell_popularity
     ),
@@ -68,17 +89,20 @@ LANGUAGE SQL STABLE AS $$
             (CASE c.importance
                 WHEN 1 THEN 1.0 WHEN 2 THEN 0.8 WHEN 3 THEN 0.6
                 WHEN 4 THEN 0.4 WHEN 5 THEN 0.2 ELSE 0.6 END)::REAL AS imp,
-            COALESCE(cp.recent_access_count::REAL / (SELECT val FROM max_pop), 0)::REAL AS pop
+            COALESCE(cp.recent_access_count::REAL / (SELECT val FROM max_pop), 0)::REAL AS pop,
+            COALESCE(g.score, 0)::REAL AS gp
         FROM cells c
         JOIN candidates ca ON ca.id = c.id
         LEFT JOIN cell_popularity cp ON cp.cell_id = c.id
+        LEFT JOIN graph g ON g.cell_id = c.id
     )
     SELECT s.id, s.content, s.summary, s.realm, s.signal, s.topic,
            s.tags, s.importance, s.created_at, s.valid_from, s.valid_until,
-           s.sem, s.kw, s.rec, s.imp, s.pop,
+           s.sem, s.kw, s.rec, s.imp, s.pop, s.gp,
            (s.sem * p_weight_semantic + s.kw * p_weight_keyword +
             s.rec * p_weight_recency + s.imp * p_weight_importance +
-            s.pop * p_weight_popularity)::REAL AS score_total
+            s.pop * p_weight_popularity +
+            s.gp  * p_weight_graph_proximity)::REAL AS score_total
     FROM scored s WHERE s.sem > 0.3 OR s.kw > 0
     ORDER BY score_total DESC, s.id ASC LIMIT p_limit;
 $$;

--- a/java-server/src/test/java/com/hivemem/agents/AgentFleetIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/agents/AgentFleetIntegrationTest.java
@@ -7,6 +7,7 @@ import com.hivemem.embedding.EmbeddingClient;
 import com.hivemem.embedding.FixedEmbeddingClient;
 import com.hivemem.search.CellSearchRepository;
 import com.hivemem.search.KgSearchRepository;
+import com.hivemem.search.SearchWeightsProperties;
 import com.hivemem.tools.read.ReadToolService;
 import com.hivemem.write.WriteToolRepository;
 import com.hivemem.write.AdminToolRepository;
@@ -317,6 +318,7 @@ class AgentFleetIntegrationTest {
             WriteToolService.class,
             WriteToolRepository.class,
             ReadToolService.class,
+            SearchWeightsProperties.class,
             CellReadRepository.class,
             CellSearchRepository.class,
             KgSearchRepository.class,

--- a/java-server/src/test/java/com/hivemem/blueprints/BlueprintsIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/blueprints/BlueprintsIntegrationTest.java
@@ -7,6 +7,7 @@ import com.hivemem.embedding.EmbeddingClient;
 import com.hivemem.embedding.FixedEmbeddingClient;
 import com.hivemem.search.CellSearchRepository;
 import com.hivemem.search.KgSearchRepository;
+import com.hivemem.search.SearchWeightsProperties;
 import com.hivemem.tools.read.ReadToolService;
 import com.hivemem.write.WriteToolRepository;
 import com.hivemem.write.AdminToolRepository;
@@ -257,6 +258,7 @@ class BlueprintsIntegrationTest {
             WriteToolService.class,
             WriteToolRepository.class,
             ReadToolService.class,
+            SearchWeightsProperties.class,
             CellReadRepository.class,
             CellSearchRepository.class,
             KgSearchRepository.class,

--- a/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
+++ b/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
@@ -38,7 +38,7 @@ class FlywayMigrationParityTest {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().info().pending()).isEmpty();
             assertThat(harness.dsl().fetchCount(DSL.table("migration_baseline"))).isEqualTo(1);
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(16);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(17);
         }
     }
 
@@ -46,7 +46,7 @@ class FlywayMigrationParityTest {
     void migrationsAreIdempotentOnSecondRun() throws SQLException {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().migrate().migrationsExecuted).isZero();
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(16);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(17);
         }
     }
 

--- a/java-server/src/test/java/com/hivemem/graph/GraphSearchIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/graph/GraphSearchIntegrationTest.java
@@ -7,6 +7,7 @@ import com.hivemem.embedding.EmbeddingClient;
 import com.hivemem.embedding.FixedEmbeddingClient;
 import com.hivemem.search.CellSearchRepository;
 import com.hivemem.search.KgSearchRepository;
+import com.hivemem.search.SearchWeightsProperties;
 import com.hivemem.tools.read.ReadToolService;
 import com.hivemem.write.WriteToolRepository;
 import com.hivemem.write.AdminToolRepository;
@@ -328,6 +329,7 @@ class GraphSearchIntegrationTest {
             WriteToolService.class,
             WriteToolRepository.class,
             ReadToolService.class,
+            SearchWeightsProperties.class,
             CellReadRepository.class,
             CellSearchRepository.class,
             KgSearchRepository.class,

--- a/java-server/src/test/java/com/hivemem/hooks/ContextFormatterTest.java
+++ b/java-server/src/test/java/com/hivemem/hooks/ContextFormatterTest.java
@@ -1,0 +1,73 @@
+package com.hivemem.hooks;
+
+import com.hivemem.search.CellSearchRepository.RankedRow;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContextFormatterTest {
+
+    private final ContextFormatter f = new ContextFormatter();
+
+    @Test
+    void formatsSingleCellAsCompactXmlWithTurn() {
+        UUID id = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        RankedRow row = new RankedRow(id, "full",
+                "Phase 3 plan: SDK wrapper, 4 weeks",
+                "engineering", "facts", "events", List.of("plan"), 1,
+                OffsetDateTime.now(), null, null,
+                0.8, 0.0, 0.0, 0.0, 0.0, 0.0, 0.85);
+
+        String out = f.format(List.of(row), 23);
+
+        assertThat(out).startsWith("<hivemem_context turn=\"23\">");
+        assertThat(out).contains("(id: 11111111-1111-1111-1111-111111111111)");
+        assertThat(out).contains("Phase 3 plan: SDK wrapper, 4 weeks");
+        assertThat(out).endsWith("</hivemem_context>");
+    }
+
+    @Test
+    void emptyListReturnsEmptyString() {
+        assertThat(f.format(List.of(), 1)).isEmpty();
+    }
+
+    @Test
+    void nullListReturnsEmptyString() {
+        assertThat(f.format(null, 1)).isEmpty();
+    }
+
+    @Test
+    void multipleCellsRenderAsBulletList() {
+        RankedRow a = sampleRow(UUID.randomUUID(), "first summary");
+        RankedRow b = sampleRow(UUID.randomUUID(), "second summary");
+
+        String out = f.format(List.of(a, b), 7);
+
+        assertThat(out).contains("- first summary");
+        assertThat(out).contains("- second summary");
+    }
+
+    @Test
+    void fallsBackToContentWhenSummaryIsBlank() {
+        UUID id = UUID.randomUUID();
+        RankedRow row = new RankedRow(id, "this is the full content",
+                "", // blank summary
+                "r", "s", "t", List.of(), 3,
+                OffsetDateTime.now(), null, null,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5);
+
+        String out = f.format(List.of(row), 1);
+
+        assertThat(out).contains("this is the full content");
+    }
+
+    private RankedRow sampleRow(UUID id, String summary) {
+        return new RankedRow(id, "x", summary, "r", "s", "t",
+                List.of(), 3, OffsetDateTime.now(), null, null,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5);
+    }
+}

--- a/java-server/src/test/java/com/hivemem/hooks/HookContextServiceTest.java
+++ b/java-server/src/test/java/com/hivemem/hooks/HookContextServiceTest.java
@@ -1,0 +1,111 @@
+package com.hivemem.hooks;
+
+import com.hivemem.embedding.EmbeddingClient;
+import com.hivemem.search.CellSearchRepository;
+import com.hivemem.search.CellSearchRepository.RankedRow;
+import com.hivemem.search.SearchWeightsProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class HookContextServiceTest {
+
+    private CellSearchRepository repo;
+    private EmbeddingClient embed;
+    private HookContextService svc;
+    private HookProperties props;
+
+    @BeforeEach
+    void setUp() {
+        repo = Mockito.mock(CellSearchRepository.class);
+        embed = Mockito.mock(EmbeddingClient.class);
+        when(embed.encodeQuery(anyString())).thenReturn(List.of(0f));
+        props = new HookProperties();
+        SearchWeightsProperties weights = new SearchWeightsProperties();
+        svc = new HookContextService(repo, embed, new SkipHeuristics(),
+                new SessionInjectionCache(), new ContextFormatter(),
+                props, weights);
+    }
+
+    @Test
+    void skipsTrivialPrompt() {
+        String out = svc.contextFor(new HookContextRequest("UserPromptSubmit", "ok", "s1", null));
+        assertThat(out).isEmpty();
+        Mockito.verifyNoInteractions(repo);
+    }
+
+    @Test
+    void emptyWhenAllResultsBelowThreshold() {
+        when(repo.rankedSearch(any(), anyString(), any(), any(), any(), anyInt(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(List.of(weakRow()));
+        String out = svc.contextFor(new HookContextRequest(
+                "UserPromptSubmit", "What was the plan for project X phase 3?", "s1", null));
+        assertThat(out).isEmpty();
+    }
+
+    @Test
+    void formatsResultsAboveThreshold() {
+        when(repo.rankedSearch(any(), anyString(), any(), any(), any(), anyInt(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(List.of(strongRow()));
+        String out = svc.contextFor(new HookContextRequest(
+                "UserPromptSubmit", "What was the plan for project X phase 3?", "s1", null));
+        assertThat(out).contains("<hivemem_context");
+    }
+
+    @Test
+    void dedupSuppressesRepeatedInjection() {
+        RankedRow row = strongRow();
+        when(repo.rankedSearch(any(), anyString(), any(), any(), any(), anyInt(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(List.of(row));
+        var req = new HookContextRequest(
+                "UserPromptSubmit", "What was the plan for project X phase 3?", "s1", null);
+        svc.contextFor(req);
+        String second = svc.contextFor(req);
+        assertThat(second).isEmpty();
+    }
+
+    @Test
+    void disabledReturnsEmpty() {
+        props.setEnabled(false);
+        String out = svc.contextFor(new HookContextRequest(
+                "UserPromptSubmit", "What was the plan for project X phase 3?", "s1", null));
+        assertThat(out).isEmpty();
+        Mockito.verifyNoInteractions(repo);
+    }
+
+    @Test
+    void searchExceptionReturnsEmpty() {
+        when(repo.rankedSearch(any(), anyString(), any(), any(), any(), anyInt(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenThrow(new RuntimeException("db down"));
+        String out = svc.contextFor(new HookContextRequest(
+                "UserPromptSubmit", "What was the plan for project X phase 3?", "s1", null));
+        assertThat(out).isEmpty();
+    }
+
+    private RankedRow weakRow() {
+        return new RankedRow(UUID.randomUUID(), "x", "x", "r", "s", "t",
+                List.of(), 3, OffsetDateTime.now(), null, null,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.10);
+    }
+
+    private RankedRow strongRow() {
+        return new RankedRow(UUID.randomUUID(), "x", "Phase 3 plan", "r", "s", "t",
+                List.of(), 1, OffsetDateTime.now(), null, null,
+                0.9, 0.0, 0.0, 0.0, 0.0, 0.0, 0.90);
+    }
+}

--- a/java-server/src/test/java/com/hivemem/hooks/HookPropertiesTest.java
+++ b/java-server/src/test/java/com/hivemem/hooks/HookPropertiesTest.java
@@ -1,0 +1,35 @@
+package com.hivemem.hooks;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = HookPropertiesTest.TestConfig.class)
+@TestPropertySource(properties = {
+        "hivemem.hooks.enabled=false",
+        "hivemem.hooks.relevance-threshold=0.42",
+        "hivemem.hooks.max-cells=7",
+        "hivemem.hooks.dedup-window-turns=11",
+})
+class HookPropertiesTest {
+
+    @Configuration
+    @EnableConfigurationProperties(HookProperties.class)
+    static class TestConfig {
+    }
+
+    @Autowired HookProperties props;
+
+    @Test
+    void bindsAllFieldsFromYaml() {
+        assertThat(props.isEnabled()).isFalse();
+        assertThat(props.getRelevanceThreshold()).isEqualTo(0.42);
+        assertThat(props.getMaxCells()).isEqualTo(7);
+        assertThat(props.getDedupWindowTurns()).isEqualTo(11);
+    }
+}

--- a/java-server/src/test/java/com/hivemem/hooks/HooksAuditLoggingTest.java
+++ b/java-server/src/test/java/com/hivemem/hooks/HooksAuditLoggingTest.java
@@ -1,0 +1,123 @@
+package com.hivemem.hooks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hivemem.auth.AuthFilter;
+import com.hivemem.auth.AuthPrincipal;
+import com.hivemem.auth.AuthRole;
+import com.hivemem.auth.TokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import org.springframework.test.context.web.ServletTestExecutionListener;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith({SpringExtension.class, OutputCaptureExtension.class})
+@ContextConfiguration(classes = HooksAuditLoggingTest.TestConfig.class)
+@TestExecutionListeners(
+        listeners = {
+                ServletTestExecutionListener.class,
+                DirtiesContextBeforeModesTestExecutionListener.class,
+                DependencyInjectionTestExecutionListener.class,
+                DirtiesContextTestExecutionListener.class
+        },
+        mergeMode = TestExecutionListeners.MergeMode.REPLACE_DEFAULTS
+)
+@WebAppConfiguration
+class HooksAuditLoggingTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private AuthFilter authFilter;
+
+    @Autowired
+    private HookContextService hookContextService;
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(hookContextService);
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilters(authFilter)
+                .build();
+    }
+
+    @Test
+    void hookCallEmitsAuditLogLineWithoutPromptContent(CapturedOutput output) throws Exception {
+        Mockito.when(hookContextService.contextFor(any())).thenReturn("");
+
+        String secret = "super secret prompt that must not appear in logs";
+        String body = om.writeValueAsString(Map.of(
+                "hook_event_name", "UserPromptSubmit",
+                "prompt", secret,
+                "session_id", "audit-1",
+                "cwd", "/x"));
+
+        mockMvc.perform(post("/hooks/context")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        assertThat(output).contains("HOOK_CALL");
+        assertThat(output).contains("session=audit-1");
+        assertThat(output).contains("event=UserPromptSubmit");
+        assertThat(output).contains("promptLen=" + secret.length());
+        assertThat(output).doesNotContain(secret);
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableWebMvc
+    @Import({
+            AuthFilter.class,
+            com.hivemem.auth.RateLimiter.class,
+            HooksController.class
+    })
+    static class TestConfig {
+
+        @Bean
+        HookContextService hookContextService() {
+            return Mockito.mock(HookContextService.class);
+        }
+
+        @Bean
+        @org.springframework.context.annotation.Primary
+        TokenService tokenService() {
+            return new com.hivemem.auth.support.FixedTokenService(token -> switch (token) {
+                case "good-token" -> Optional.of(new AuthPrincipal("token-1", AuthRole.WRITER));
+                default -> Optional.empty();
+            });
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/hooks/HooksAuthSmokeTest.java
+++ b/java-server/src/test/java/com/hivemem/hooks/HooksAuthSmokeTest.java
@@ -1,0 +1,63 @@
+package com.hivemem.hooks;
+
+import com.hivemem.auth.AuthFilter;
+import com.hivemem.auth.AuthPrincipal;
+import com.hivemem.auth.RateLimiter;
+import com.hivemem.auth.TokenService;
+import com.hivemem.auth.support.FixedTokenService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Smoke test verifying that {@link AuthFilter} runs against {@code /hooks/*} paths.
+ *
+ * <p>Even though the real {@code HooksController} does not exist yet, we install a
+ * dummy controller mapped to {@code POST /hooks/context}. The filter must reject the
+ * unauthenticated request with HTTP 401 before any controller dispatch — proving the
+ * upcoming hook endpoint will inherit the existing token-auth pipeline.
+ */
+@WebMvcTest(controllers = HooksAuthSmokeTest.StubHooksController.class)
+@Import({AuthFilter.class, RateLimiter.class, HooksAuthSmokeTest.HooksAuthSmokeTestConfig.class})
+class HooksAuthSmokeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void postHooksContextWithoutBearerTokenReturnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/hooks/context"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class HooksAuthSmokeTestConfig {
+
+        @Bean
+        @Primary
+        TokenService tokenService() {
+            return new FixedTokenService(token -> Optional.<AuthPrincipal>empty());
+        }
+    }
+
+    @RestController
+    static class StubHooksController {
+
+        @PostMapping("/hooks/context")
+        String handle() {
+            return "should-not-reach";
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/hooks/HooksControllerTest.java
+++ b/java-server/src/test/java/com/hivemem/hooks/HooksControllerTest.java
@@ -1,0 +1,147 @@
+package com.hivemem.hooks;
+
+import com.hivemem.auth.AuthFilter;
+import com.hivemem.auth.AuthPrincipal;
+import com.hivemem.auth.AuthRole;
+import com.hivemem.auth.TokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import org.springframework.test.context.web.ServletTestExecutionListener;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.containsString;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = HooksControllerTest.TestConfig.class)
+@TestExecutionListeners(
+        listeners = {
+                ServletTestExecutionListener.class,
+                DirtiesContextBeforeModesTestExecutionListener.class,
+                DependencyInjectionTestExecutionListener.class,
+                DirtiesContextTestExecutionListener.class
+        },
+        mergeMode = TestExecutionListeners.MergeMode.REPLACE_DEFAULTS
+)
+@WebAppConfiguration
+class HooksControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private AuthFilter authFilter;
+
+    @Autowired
+    private HookContextService hookContextService;
+
+    private MockMvc mockMvc;
+
+    private static final String BODY = """
+            {"hook_event_name":"UserPromptSubmit","prompt":"What is the project plan?","session_id":"s-1","cwd":"/x"}
+            """;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(hookContextService);
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilters(authFilter)
+                .build();
+    }
+
+    @Test
+    void returnsFormattedContextOnHit() throws Exception {
+        Mockito.when(hookContextService.contextFor(any()))
+                .thenReturn("<hivemem_context turn=\"1\">hello</hivemem_context>");
+
+        mockMvc.perform(post("/hooks/context")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hookSpecificOutput.hookEventName").value("UserPromptSubmit"))
+                .andExpect(jsonPath("$.hookSpecificOutput.additionalContext")
+                        .value(containsString("hivemem_context")));
+    }
+
+    @Test
+    void returnsEmptyContextOnSkip() throws Exception {
+        Mockito.when(hookContextService.contextFor(any())).thenReturn("");
+
+        mockMvc.perform(post("/hooks/context")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hookSpecificOutput.hookEventName").value("UserPromptSubmit"))
+                .andExpect(jsonPath("$.hookSpecificOutput.additionalContext").value(""));
+    }
+
+    @Test
+    void returnsEmptyContextOnInternalFailure() throws Exception {
+        Mockito.when(hookContextService.contextFor(any()))
+                .thenThrow(new RuntimeException("boom"));
+
+        mockMvc.perform(post("/hooks/context")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer good-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hookSpecificOutput.additionalContext").value(""));
+    }
+
+    @Test
+    void returnsUnauthorizedWithoutBearerToken() throws Exception {
+        mockMvc.perform(post("/hooks/context")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableWebMvc
+    @Import({
+            AuthFilter.class,
+            com.hivemem.auth.RateLimiter.class,
+            HooksController.class
+    })
+    static class TestConfig {
+
+        @Bean
+        HookContextService hookContextService() {
+            return Mockito.mock(HookContextService.class);
+        }
+
+        @Bean
+        @org.springframework.context.annotation.Primary
+        TokenService tokenService() {
+            return new com.hivemem.auth.support.FixedTokenService(token -> switch (token) {
+                case "good-token" -> Optional.of(new AuthPrincipal("token-1", AuthRole.WRITER));
+                default -> Optional.empty();
+            });
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/hooks/HooksIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/hooks/HooksIntegrationTest.java
@@ -1,0 +1,189 @@
+package com.hivemem.hooks;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import com.hivemem.auth.AuthPrincipal;
+import com.hivemem.auth.AuthRole;
+import com.hivemem.auth.RateLimiter;
+import com.hivemem.auth.TokenService;
+import com.hivemem.embedding.EmbeddingClient;
+import com.hivemem.embedding.FixedEmbeddingClient;
+import com.hivemem.write.WriteToolService;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end integration test for the hook endpoint.
+ *
+ * <p>Boots the full Spring Boot context against a real Postgres testcontainer and
+ * exercises the chain HTTP -> AuthFilter -> HooksController -> HookContextService ->
+ * EmbeddingClient -> CellSearchRepository -> ranked_search SQL -> ContextFormatter.
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(HooksIntegrationTest.TestConfig.class)
+@TestPropertySource(properties = "hivemem.hooks.relevance-threshold=0.0")
+@Testcontainers
+class HooksIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("hivemem")
+            .withUsername("hivemem")
+            .withPassword("hivemem")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null
+                            ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig())
+                            .withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
+    }
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private DSLContext dslContext;
+
+    @Autowired
+    private RateLimiter rateLimiter;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private WriteToolService writeToolService;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @BeforeEach
+    void resetDatabase() {
+        rateLimiter.clearAll();
+        dslContext.execute("TRUNCATE TABLE agent_diary, cell_references, references_, blueprints, identity, agents, facts, tunnels, cells CASCADE");
+    }
+
+    @Test
+    void hookEndpointInjectsHivememContextWithSeededCellId() throws Exception {
+        // Seed a cell whose content/summary contain the deterministic "semantic"
+        // marker recognised by FixedEmbeddingClient -> [1,0,0]. The query prompt
+        // also contains "semantic" so embeddings collide and similarity is 1.0.
+        Map<String, Object> seeded = writeToolService.addCell(
+                new AuthPrincipal("integration-writer", AuthRole.WRITER),
+                "semantic plan: project X phase 3 SDK wrapper rollout in 4 weeks",
+                "eng",
+                "facts",
+                "planning",
+                "system",
+                java.util.List.of(),
+                1,
+                "Phase 3 plan for project X: SDK wrapper, 4 weeks (semantic)",
+                java.util.List.of(),
+                null,
+                null,
+                "committed",
+                null,
+                null
+        );
+        UUID seededId = UUID.fromString((String) seeded.get("id"));
+
+        String body = """
+                {"hook_event_name":"UserPromptSubmit",
+                 "prompt":"semantic: what was the plan for project X phase 3?",
+                 "session_id":"it-1"}
+                """;
+
+        ResponseEntity<String> response = post("/hooks/context", body, "good-token");
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+
+        JsonNode root = objectMapper.readTree(response.getBody());
+        assertThat(root.path("hookSpecificOutput").path("hookEventName").asText())
+                .isEqualTo("UserPromptSubmit");
+        String additional = root.path("hookSpecificOutput").path("additionalContext").asText();
+        assertThat(additional).contains("hivemem_context");
+        assertThat(additional).contains(seededId.toString());
+    }
+
+    @Test
+    void trivialPromptReturnsEmptyAdditionalContext() throws Exception {
+        String body = """
+                {"hook_event_name":"UserPromptSubmit",
+                 "prompt":"ok",
+                 "session_id":"it-2"}
+                """;
+
+        ResponseEntity<String> response = post("/hooks/context", body, "good-token");
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+
+        JsonNode root = objectMapper.readTree(response.getBody());
+        assertThat(root.path("hookSpecificOutput").path("hookEventName").asText())
+                .isEqualTo("UserPromptSubmit");
+        assertThat(root.path("hookSpecificOutput").path("additionalContext").asText())
+                .isEmpty();
+    }
+
+    private ResponseEntity<String> post(String path, String body, String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        return restTemplate.exchange(
+                "http://localhost:" + port + path,
+                HttpMethod.POST,
+                new HttpEntity<>(body, headers),
+                String.class
+        );
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestConfig {
+
+        @Bean
+        @org.springframework.context.annotation.Primary
+        TokenService tokenService() {
+            return new com.hivemem.auth.support.FixedTokenService(token -> switch (token) {
+                case "good-token" -> Optional.of(new AuthPrincipal("token-1", AuthRole.WRITER));
+                default -> Optional.empty();
+            });
+        }
+
+        @Bean
+        @org.springframework.context.annotation.Primary
+        EmbeddingClient embeddingClient() {
+            return new FixedEmbeddingClient();
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/hooks/SessionInjectionCacheTest.java
+++ b/java-server/src/test/java/com/hivemem/hooks/SessionInjectionCacheTest.java
@@ -1,0 +1,51 @@
+package com.hivemem.hooks;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SessionInjectionCacheTest {
+
+    @Test
+    void recentlyInjectedTrueWithinDedupWindow() {
+        var cache = new SessionInjectionCache(Duration.ofHours(1), 5);
+        UUID cell = UUID.randomUUID();
+        cache.recordInjection("session-1", cell, 10);
+        assertThat(cache.recentlyInjected("session-1", cell, 12)).isTrue();
+    }
+
+    @Test
+    void recentlyInjectedFalseOutsideDedupWindow() {
+        var cache = new SessionInjectionCache(Duration.ofHours(1), 5);
+        UUID cell = UUID.randomUUID();
+        cache.recordInjection("session-1", cell, 10);
+        assertThat(cache.recentlyInjected("session-1", cell, 17)).isFalse();
+    }
+
+    @Test
+    void differentSessionsAreIsolated() {
+        var cache = new SessionInjectionCache(Duration.ofHours(1), 5);
+        UUID cell = UUID.randomUUID();
+        cache.recordInjection("session-1", cell, 1);
+        assertThat(cache.recentlyInjected("session-2", cell, 1)).isFalse();
+    }
+
+    @Test
+    void unknownCellIsNotConsideredRecentlyInjected() {
+        var cache = new SessionInjectionCache(Duration.ofHours(1), 5);
+        assertThat(cache.recentlyInjected("session-1", UUID.randomUUID(), 1)).isFalse();
+    }
+
+    @Test
+    void boundaryAtExactWindowEdgeIsExcluded() {
+        // dedup window = 5 means turns t and t+1..t+4 are suppressed; turn t+5 is allowed
+        var cache = new SessionInjectionCache(Duration.ofHours(1), 5);
+        UUID cell = UUID.randomUUID();
+        cache.recordInjection("s", cell, 0);
+        assertThat(cache.recentlyInjected("s", cell, 4)).isTrue();
+        assertThat(cache.recentlyInjected("s", cell, 5)).isFalse();
+    }
+}

--- a/java-server/src/test/java/com/hivemem/hooks/SkipHeuristicsTest.java
+++ b/java-server/src/test/java/com/hivemem/hooks/SkipHeuristicsTest.java
@@ -1,0 +1,50 @@
+package com.hivemem.hooks;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SkipHeuristicsTest {
+
+    private final SkipHeuristics h = new SkipHeuristics();
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ok", "yes", "no", "continue", "go on", "thanks", "weiter", "danke"})
+    void shortMetaPhrasesAreSkipped(String prompt) {
+        assertThat(h.evaluate(prompt).skip()).isTrue();
+    }
+
+    @Test
+    void wordCountBelowFourIsSkipped() {
+        assertThat(h.evaluate("do that thing").skip()).isTrue();
+    }
+
+    @Test
+    void pureCodeBlockIsSkipped() {
+        assertThat(h.evaluate("```java\nint x = 1;\n```").skip()).isTrue();
+    }
+
+    @Test
+    void nomemPrefixForcesSkip() {
+        assertThat(h.evaluate("!nomem tell me about the architecture").skip()).isTrue();
+    }
+
+    @Test
+    void normalQuestionIsNotSkipped() {
+        assertThat(h.evaluate("What was the plan for project X phase 3?").skip()).isFalse();
+    }
+
+    @Test
+    void memPrefixForcesNoSkipEvenIfShort() {
+        assertThat(h.evaluate("!mem ok").skip()).isFalse();
+    }
+
+    @Test
+    void nullAndEmptyAreSkipped() {
+        assertThat(h.evaluate(null).skip()).isTrue();
+        assertThat(h.evaluate("").skip()).isTrue();
+        assertThat(h.evaluate("   ").skip()).isTrue();
+    }
+}

--- a/java-server/src/test/java/com/hivemem/search/CellSearchRepositoryGraphTest.java
+++ b/java-server/src/test/java/com/hivemem/search/CellSearchRepositoryGraphTest.java
@@ -167,6 +167,7 @@ class CellSearchRepositoryGraphTest {
             WriteToolService.class,
             WriteToolRepository.class,
             ReadToolService.class,
+            SearchWeightsProperties.class,
             CellReadRepository.class,
             CellSearchRepository.class,
             KgSearchRepository.class,

--- a/java-server/src/test/java/com/hivemem/search/CellSearchRepositoryGraphTest.java
+++ b/java-server/src/test/java/com/hivemem/search/CellSearchRepositoryGraphTest.java
@@ -1,0 +1,198 @@
+package com.hivemem.search;
+
+import com.hivemem.auth.AuthPrincipal;
+import com.hivemem.auth.AuthRole;
+import com.hivemem.cells.CellReadRepository;
+import com.hivemem.embedding.EmbeddingClient;
+import com.hivemem.embedding.EmbeddingStateRepository;
+import com.hivemem.embedding.FixedEmbeddingClient;
+import com.hivemem.tools.read.ReadToolService;
+import com.hivemem.write.AdminToolRepository;
+import com.hivemem.write.AdminToolService;
+import com.hivemem.write.WriteToolRepository;
+import com.hivemem.write.WriteToolService;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the Java {@link CellSearchRepository#rankedSearch} method exposes
+ * the new {@code scoreGraphProximity} field via {@link CellSearchRepository.RankedRow}
+ * when called with the new 12th weight argument.
+ */
+@SpringBootTest(
+        classes = CellSearchRepositoryGraphTest.TestApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@ActiveProfiles("test")
+@Testcontainers
+class CellSearchRepositoryGraphTest {
+
+    private static final AuthPrincipal WRITER = new AuthPrincipal("writer-1", AuthRole.WRITER);
+    private static final OffsetDateTime BASE_TIME = OffsetDateTime.parse("2026-04-15T09:00:00Z");
+    private static final int DIMS = 1024;
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("hivemem")
+            .withUsername("hivemem")
+            .withPassword("hivemem")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null
+                            ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig())
+                            .withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
+    }
+
+    @Autowired
+    private WriteToolService writeToolService;
+
+    @Autowired
+    private CellSearchRepository cellSearchRepository;
+
+    @Autowired
+    private DSLContext dslContext;
+
+    @Autowired
+    private EmbeddingStateRepository embeddingStateRepository;
+
+    @BeforeEach
+    void resetDatabase() {
+        dslContext.execute("TRUNCATE TABLE agent_diary, cell_references, references_, blueprints, identity, agents, facts, tunnels, cells CASCADE");
+        embeddingStateRepository.replaceRankedSearchFunction(DIMS);
+    }
+
+    @Test
+    void rankedSearchSurfacesGraphProximityScore() {
+        UUID anchor = createCell("semantic anchor cell");
+        for (int i = 0; i < 24; i++) {
+            createCell("semantic filler cell " + i);
+        }
+        UUID connected = createCell("alpha bridge target");
+        UUID unconnected = createCell("alpha lonely target");
+
+        writeToolService.addTunnel(WRITER, anchor, connected, "builds_on", null, "committed");
+
+        List<Float> queryEmbedding = paddedEmbedding(1.0f, 0.0f, 0.0f);
+
+        List<CellSearchRepository.RankedRow> rows = cellSearchRepository.rankedSearch(
+                queryEmbedding,
+                "alpha",
+                null,
+                null,
+                null,
+                100,
+                0.30,
+                0.15,
+                0.15,
+                0.15,
+                0.15,
+                0.10
+        );
+
+        assertThat(rows).isNotEmpty();
+        Map<UUID, CellSearchRepository.RankedRow> byId = new java.util.HashMap<>();
+        for (CellSearchRepository.RankedRow row : rows) {
+            byId.put(row.id(), row);
+        }
+        assertThat(byId).containsKeys(connected, unconnected);
+        assertThat(byId.get(connected).scoreGraphProximity()).isGreaterThan(0.0);
+        assertThat(byId.get(unconnected).scoreGraphProximity()).isEqualTo(0.0);
+    }
+
+    // ---- helpers ----
+
+    private UUID createCell(String content) {
+        Map<String, Object> result = writeToolService.addCell(
+                WRITER,
+                content,
+                "test",
+                "facts",
+                null,
+                "system",
+                List.of(),
+                1,
+                null,
+                List.of(),
+                null,
+                null,
+                "committed",
+                BASE_TIME,
+                null
+        );
+        return UUID.fromString((String) result.get("id"));
+    }
+
+    private static List<Float> paddedEmbedding(float d0, float d1, float d2) {
+        List<Float> vec = new ArrayList<>(Collections.nCopies(DIMS, 0.0f));
+        vec.set(0, d0);
+        vec.set(1, d1);
+        vec.set(2, d2);
+        return vec;
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @Import({
+            WriteToolService.class,
+            WriteToolRepository.class,
+            ReadToolService.class,
+            CellReadRepository.class,
+            CellSearchRepository.class,
+            KgSearchRepository.class,
+            AdminToolRepository.class,
+            EmbeddingStateRepository.class,
+            TestConfig.class
+    })
+    static class TestApplication {
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestConfig {
+
+        @Bean
+        @Primary
+        EmbeddingClient embeddingClient() {
+            return new FixedEmbeddingClient();
+        }
+
+        @Bean
+        AdminToolService adminToolService(AdminToolRepository adminToolRepository) {
+            return new AdminToolService(adminToolRepository, new com.hivemem.embedding.EmbeddingMigrationService(
+                    new FixedEmbeddingClient(), null) {
+                @Override
+                public void run(org.springframework.boot.ApplicationArguments args) {}
+            });
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/search/GraphProximityFunctionTest.java
+++ b/java-server/src/test/java/com/hivemem/search/GraphProximityFunctionTest.java
@@ -1,0 +1,218 @@
+package com.hivemem.search;
+
+import com.hivemem.auth.AuthPrincipal;
+import com.hivemem.auth.AuthRole;
+import com.hivemem.cells.CellReadRepository;
+import com.hivemem.embedding.EmbeddingClient;
+import com.hivemem.embedding.FixedEmbeddingClient;
+import com.hivemem.tools.read.ReadToolService;
+import com.hivemem.write.AdminToolRepository;
+import com.hivemem.write.AdminToolService;
+import com.hivemem.write.WriteToolRepository;
+import com.hivemem.write.WriteToolService;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Tests for the {@code graph_proximity_scores} SQL function added in V0018.
+ *
+ * <p>The function returns one row per neighbour of any anchor, with an aggregated
+ * score = max over paths of (relation_weight * 1/depth). Anchors themselves are
+ * excluded from the result set.
+ */
+@SpringBootTest(
+        classes = GraphProximityFunctionTest.TestApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@ActiveProfiles("test")
+@Testcontainers
+class GraphProximityFunctionTest {
+
+    private static final AuthPrincipal WRITER = new AuthPrincipal("writer-1", AuthRole.WRITER);
+    private static final OffsetDateTime BASE_TIME = OffsetDateTime.parse("2026-04-15T09:00:00Z");
+
+    private static final String DEFAULT_WEIGHTS_JSON = "{"
+            + "\"builds_on\":1.0,"
+            + "\"refines\":0.8,"
+            + "\"related_to\":0.6,"
+            + "\"contradicts\":0.4"
+            + "}";
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("hivemem")
+            .withUsername("hivemem")
+            .withPassword("hivemem")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null
+                            ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig())
+                            .withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
+    }
+
+    @Autowired
+    private WriteToolService writeToolService;
+
+    @Autowired
+    private DSLContext dslContext;
+
+    @BeforeEach
+    void resetDatabase() {
+        dslContext.execute("TRUNCATE TABLE agent_diary, cell_references, references_, blueprints, identity, agents, facts, tunnels, cells CASCADE");
+    }
+
+    @Test
+    void directNeighbourScoresOneAndAnchorIsExcluded() {
+        UUID idA = createCell("Anchor A");
+        UUID idB = createCell("Neighbour B");
+        UUID idC = createCell("Unrelated C");
+
+        addTunnel(idA, idB, "builds_on");
+
+        Map<UUID, Float> scores = callGraphProximity(List.of(idA), DEFAULT_WEIGHTS_JSON, 2);
+
+        // B is a direct neighbour via builds_on (weight=1.0) at depth 1 -> score = 1.0 * 1/1 = 1.0
+        assertThat(scores).containsKey(idB);
+        assertThat(scores.get(idB)).isCloseTo(1.0f, within(1e-4f));
+        // C has no edges from A
+        assertThat(scores).doesNotContainKey(idC);
+        // Anchor itself is excluded
+        assertThat(scores).doesNotContainKey(idA);
+    }
+
+    @Test
+    void depthTwoChainAppliesRelationWeightAndDepthDecay() {
+        // A -builds_on-> B -related_to-> C
+        UUID idA = createCell("Chain A");
+        UUID idB = createCell("Chain B");
+        UUID idC = createCell("Chain C");
+
+        addTunnel(idA, idB, "builds_on");
+        addTunnel(idB, idC, "related_to");
+
+        Map<UUID, Float> scores = callGraphProximity(List.of(idA), DEFAULT_WEIGHTS_JSON, 2);
+
+        // B: depth 1 via builds_on (1.0) -> 1.0 * 1/1 = 1.0
+        assertThat(scores).containsKey(idB);
+        assertThat(scores.get(idB)).isCloseTo(1.0f, within(1e-4f));
+
+        // C: depth 2; path_score = 1.0 (seed) * 1.0 (builds_on) * 1/1
+        //                       then * 0.6 (related_to) * 1/2 = 0.3
+        assertThat(scores).containsKey(idC);
+        assertThat(scores.get(idC)).isCloseTo(0.3f, within(1e-4f));
+
+        // Anchor excluded
+        assertThat(scores).doesNotContainKey(idA);
+    }
+
+    // ---- helpers ----
+
+    private UUID createCell(String content) {
+        Map<String, Object> result = writeToolService.addCell(
+                WRITER,
+                content,
+                "test",
+                "facts",
+                null,
+                "system",
+                List.of(),
+                1,
+                null,
+                List.of(),
+                null,
+                null,
+                "committed",
+                BASE_TIME,
+                null
+        );
+        return UUID.fromString((String) result.get("id"));
+    }
+
+    private void addTunnel(UUID from, UUID to, String relation) {
+        writeToolService.addTunnel(WRITER, from, to, relation, null, "committed");
+    }
+
+    private Map<UUID, Float> callGraphProximity(List<UUID> anchors, String weightsJson, int maxDepth) {
+        UUID[] anchorArray = anchors.toArray(new UUID[0]);
+        Result<Record> result = dslContext.resultQuery(
+                "SELECT cell_id, score FROM graph_proximity_scores(?::uuid[], ?::jsonb, ?)",
+                anchorArray,
+                weightsJson,
+                maxDepth
+        ).fetch();
+        Map<UUID, Float> scores = new HashMap<>();
+        for (Record row : result) {
+            UUID id = (UUID) row.get("cell_id");
+            Number score = (Number) row.get("score");
+            scores.put(id, score.floatValue());
+        }
+        return scores;
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @Import({
+            WriteToolService.class,
+            WriteToolRepository.class,
+            ReadToolService.class,
+            CellReadRepository.class,
+            CellSearchRepository.class,
+            KgSearchRepository.class,
+            AdminToolRepository.class,
+            TestConfig.class
+    })
+    static class TestApplication {
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestConfig {
+
+        @Bean
+        @Primary
+        EmbeddingClient embeddingClient() {
+            return new FixedEmbeddingClient();
+        }
+
+        @Bean
+        AdminToolService adminToolService(AdminToolRepository adminToolRepository) {
+            return new AdminToolService(adminToolRepository, new com.hivemem.embedding.EmbeddingMigrationService(
+                    new FixedEmbeddingClient(), null) {
+                @Override
+                public void run(org.springframework.boot.ApplicationArguments args) {}
+            });
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/search/GraphProximityFunctionTest.java
+++ b/java-server/src/test/java/com/hivemem/search/GraphProximityFunctionTest.java
@@ -188,6 +188,7 @@ class GraphProximityFunctionTest {
             WriteToolService.class,
             WriteToolRepository.class,
             ReadToolService.class,
+            SearchWeightsProperties.class,
             CellReadRepository.class,
             CellSearchRepository.class,
             KgSearchRepository.class,

--- a/java-server/src/test/java/com/hivemem/search/RankedSearchGraphSignalTest.java
+++ b/java-server/src/test/java/com/hivemem/search/RankedSearchGraphSignalTest.java
@@ -174,6 +174,7 @@ class RankedSearchGraphSignalTest {
             WriteToolService.class,
             WriteToolRepository.class,
             ReadToolService.class,
+            SearchWeightsProperties.class,
             CellReadRepository.class,
             CellSearchRepository.class,
             KgSearchRepository.class,

--- a/java-server/src/test/java/com/hivemem/search/RankedSearchGraphSignalTest.java
+++ b/java-server/src/test/java/com/hivemem/search/RankedSearchGraphSignalTest.java
@@ -1,0 +1,205 @@
+package com.hivemem.search;
+
+import com.hivemem.auth.AuthPrincipal;
+import com.hivemem.auth.AuthRole;
+import com.hivemem.cells.CellReadRepository;
+import com.hivemem.embedding.EmbeddingClient;
+import com.hivemem.embedding.EmbeddingStateRepository;
+import com.hivemem.embedding.FixedEmbeddingClient;
+import com.hivemem.tools.read.ReadToolService;
+import com.hivemem.write.AdminToolRepository;
+import com.hivemem.write.AdminToolService;
+import com.hivemem.write.WriteToolRepository;
+import com.hivemem.write.WriteToolService;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code ranked_search} surfaces a {@code score_graph_proximity}
+ * column and that the new sixth signal contributes positively to a cell's total
+ * score when it is reachable from a top-ranked anchor via a tunnel.
+ */
+@SpringBootTest(
+        classes = RankedSearchGraphSignalTest.TestApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@ActiveProfiles("test")
+@Testcontainers
+class RankedSearchGraphSignalTest {
+
+    private static final AuthPrincipal WRITER = new AuthPrincipal("writer-1", AuthRole.WRITER);
+    private static final OffsetDateTime BASE_TIME = OffsetDateTime.parse("2026-04-15T09:00:00Z");
+    private static final int DIMS = 1024;
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("hivemem")
+            .withUsername("hivemem")
+            .withPassword("hivemem")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null
+                            ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig())
+                            .withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
+    }
+
+    @Autowired
+    private WriteToolService writeToolService;
+
+    @Autowired
+    private DSLContext dslContext;
+
+    @Autowired
+    private EmbeddingStateRepository embeddingStateRepository;
+
+    @BeforeEach
+    void resetDatabase() {
+        dslContext.execute("TRUNCATE TABLE agent_diary, cell_references, references_, blueprints, identity, agents, facts, tunnels, cells CASCADE");
+        // The minimal Spring context here doesn't run EmbeddingMigrationService, so
+        // ranked_search (dropped in V0017) must be installed by the test itself.
+        embeddingStateRepository.replaceRankedSearchFunction(DIMS);
+    }
+
+    @Test
+    void connectedCellOutranksUnconnectedCellViaGraphProximity() {
+        // The anchor + 24 filler cells all contain "semantic", so the
+        // FixedEmbeddingClient assigns them the [1,0,0]-padded embedding. They
+        // saturate the top-25 anchors CTE when ranked_search is called with the
+        // [1,0,0] query embedding. `connected` and `unconnected` use different
+        // content so their hash-based embeddings keep them out of the anchor set
+        // (otherwise graph_proximity_scores would exclude `connected` because it
+        // would itself be an anchor). Both pass the sem>0.3 OR kw>0 filter via
+        // a keyword match against query_text="alpha".
+        UUID anchor = createCell("semantic anchor cell");
+        for (int i = 0; i < 24; i++) {
+            createCell("semantic filler cell " + i);
+        }
+        UUID connected = createCell("alpha bridge target");
+        UUID unconnected = createCell("alpha lonely target");
+
+        writeToolService.addTunnel(WRITER, anchor, connected, "builds_on", null, "committed");
+
+        List<Float> queryEmbedding = paddedEmbedding(1.0f, 0.0f, 0.0f);
+
+        Result<Record> result = dslContext.fetch(
+                "SELECT id, score_graph_proximity, score_total "
+                        + "FROM ranked_search(?::vector, ?, NULL, NULL, NULL, 100, "
+                        + "0.30::real, 0.15::real, 0.15::real, 0.15::real, 0.15::real, 0.10::real)",
+                queryEmbedding.toArray(new Float[0]),
+                "alpha"
+        );
+
+        Map<UUID, Double> totals = new HashMap<>();
+        Map<UUID, Double> graph = new HashMap<>();
+        for (Record row : result) {
+            UUID id = (UUID) row.get("id");
+            totals.put(id, ((Number) row.get("score_total")).doubleValue());
+            graph.put(id, ((Number) row.get("score_graph_proximity")).doubleValue());
+        }
+
+        assertThat(totals).containsKeys(connected, unconnected);
+        assertThat(graph.get(connected)).isGreaterThan(0.0);
+        assertThat(graph.get(unconnected)).isEqualTo(0.0);
+        assertThat(totals.get(connected)).isGreaterThan(totals.get(unconnected));
+    }
+
+    // ---- helpers ----
+
+    private UUID createCell(String content) {
+        Map<String, Object> result = writeToolService.addCell(
+                WRITER,
+                content,
+                "test",
+                "facts",
+                null,
+                "system",
+                List.of(),
+                1,
+                null,
+                List.of(),
+                null,
+                null,
+                "committed",
+                BASE_TIME,
+                null
+        );
+        return UUID.fromString((String) result.get("id"));
+    }
+
+    private static List<Float> paddedEmbedding(float d0, float d1, float d2) {
+        List<Float> vec = new ArrayList<>(Collections.nCopies(DIMS, 0.0f));
+        vec.set(0, d0);
+        vec.set(1, d1);
+        vec.set(2, d2);
+        return vec;
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @Import({
+            WriteToolService.class,
+            WriteToolRepository.class,
+            ReadToolService.class,
+            CellReadRepository.class,
+            CellSearchRepository.class,
+            KgSearchRepository.class,
+            AdminToolRepository.class,
+            EmbeddingStateRepository.class,
+            TestConfig.class
+    })
+    static class TestApplication {
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestConfig {
+
+        @Bean
+        @Primary
+        EmbeddingClient embeddingClient() {
+            return new FixedEmbeddingClient();
+        }
+
+        @Bean
+        AdminToolService adminToolService(AdminToolRepository adminToolRepository) {
+            return new AdminToolService(adminToolRepository, new com.hivemem.embedding.EmbeddingMigrationService(
+                    new FixedEmbeddingClient(), null) {
+                @Override
+                public void run(org.springframework.boot.ApplicationArguments args) {}
+            });
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/search/SearchWeightsPropertiesTest.java
+++ b/java-server/src/test/java/com/hivemem/search/SearchWeightsPropertiesTest.java
@@ -2,33 +2,40 @@ package com.hivemem.search;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = SearchWeightsProperties.class)
+@SpringBootTest(classes = SearchWeightsPropertiesTest.TestConfig.class)
 @TestPropertySource(properties = {
-        "hivemem.search.weights.semantic=0.30",
-        "hivemem.search.weights.keyword=0.15",
-        "hivemem.search.weights.recency=0.15",
-        "hivemem.search.weights.importance=0.15",
-        "hivemem.search.weights.popularity=0.15",
-        "hivemem.search.weights.graph-proximity=0.10",
+        "hivemem.search.weights.semantic=0.41",
+        "hivemem.search.weights.keyword=0.07",
+        "hivemem.search.weights.recency=0.13",
+        "hivemem.search.weights.importance=0.17",
+        "hivemem.search.weights.popularity=0.11",
+        "hivemem.search.weights.graph-proximity=0.23",
 })
 class SearchWeightsPropertiesTest {
+
+    @Configuration
+    @EnableConfigurationProperties(SearchWeightsProperties.class)
+    static class TestConfig {
+    }
 
     @Autowired SearchWeightsProperties props;
 
     @Test
     void weightsBindFromYaml() {
         SearchWeights w = props.toSearchWeights();
-        assertThat(w.semantic()).isEqualTo(0.30);
-        assertThat(w.keyword()).isEqualTo(0.15);
-        assertThat(w.recency()).isEqualTo(0.15);
-        assertThat(w.importance()).isEqualTo(0.15);
-        assertThat(w.popularity()).isEqualTo(0.15);
-        assertThat(w.graphProximity()).isEqualTo(0.10);
+        assertThat(w.semantic()).isEqualTo(0.41);
+        assertThat(w.keyword()).isEqualTo(0.07);
+        assertThat(w.recency()).isEqualTo(0.13);
+        assertThat(w.importance()).isEqualTo(0.17);
+        assertThat(w.popularity()).isEqualTo(0.11);
+        assertThat(w.graphProximity()).isEqualTo(0.23);
     }
 
     @Test

--- a/java-server/src/test/java/com/hivemem/search/SearchWeightsPropertiesTest.java
+++ b/java-server/src/test/java/com/hivemem/search/SearchWeightsPropertiesTest.java
@@ -1,0 +1,41 @@
+package com.hivemem.search;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = SearchWeightsProperties.class)
+@TestPropertySource(properties = {
+        "hivemem.search.weights.semantic=0.30",
+        "hivemem.search.weights.keyword=0.15",
+        "hivemem.search.weights.recency=0.15",
+        "hivemem.search.weights.importance=0.15",
+        "hivemem.search.weights.popularity=0.15",
+        "hivemem.search.weights.graph-proximity=0.10",
+})
+class SearchWeightsPropertiesTest {
+
+    @Autowired SearchWeightsProperties props;
+
+    @Test
+    void weightsBindFromYaml() {
+        SearchWeights w = props.toSearchWeights();
+        assertThat(w.semantic()).isEqualTo(0.30);
+        assertThat(w.keyword()).isEqualTo(0.15);
+        assertThat(w.recency()).isEqualTo(0.15);
+        assertThat(w.importance()).isEqualTo(0.15);
+        assertThat(w.popularity()).isEqualTo(0.15);
+        assertThat(w.graphProximity()).isEqualTo(0.10);
+    }
+
+    @Test
+    void defaultsAreSelfConsistent() {
+        SearchWeights w = SearchWeights.defaults();
+        assertThat(w.semantic() + w.keyword() + w.recency()
+                + w.importance() + w.popularity() + w.graphProximity())
+                .isEqualTo(1.00);
+    }
+}

--- a/java-server/src/test/java/com/hivemem/tools/references/ReferencesIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/references/ReferencesIntegrationTest.java
@@ -7,6 +7,7 @@ import com.hivemem.embedding.EmbeddingClient;
 import com.hivemem.embedding.FixedEmbeddingClient;
 import com.hivemem.search.CellSearchRepository;
 import com.hivemem.search.KgSearchRepository;
+import com.hivemem.search.SearchWeightsProperties;
 import com.hivemem.tools.read.ReadToolService;
 import com.hivemem.write.WriteToolRepository;
 import com.hivemem.write.AdminToolRepository;
@@ -232,6 +233,7 @@ class ReferencesIntegrationTest {
             WriteToolService.class,
             WriteToolRepository.class,
             ReadToolService.class,
+            SearchWeightsProperties.class,
             CellReadRepository.class,
             CellSearchRepository.class,
             KgSearchRepository.class,

--- a/java-server/src/test/java/com/hivemem/tools/robustness/SqlRobustnessIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/robustness/SqlRobustnessIntegrationTest.java
@@ -7,6 +7,7 @@ import com.hivemem.embedding.EmbeddingClient;
 import com.hivemem.embedding.FixedEmbeddingClient;
 import com.hivemem.search.CellSearchRepository;
 import com.hivemem.search.KgSearchRepository;
+import com.hivemem.search.SearchWeightsProperties;
 import com.hivemem.tools.read.ReadToolService;
 import com.hivemem.write.WriteToolRepository;
 import com.hivemem.write.AdminToolRepository;
@@ -236,6 +237,7 @@ class SqlRobustnessIntegrationTest {
             WriteToolService.class,
             WriteToolRepository.class,
             ReadToolService.class,
+            SearchWeightsProperties.class,
             CellReadRepository.class,
             CellSearchRepository.class,
             KgSearchRepository.class,

--- a/java-server/src/test/java/com/hivemem/tools/summarization/ProgressiveSummarizationIntegrationTest.java
+++ b/java-server/src/test/java/com/hivemem/tools/summarization/ProgressiveSummarizationIntegrationTest.java
@@ -7,6 +7,7 @@ import com.hivemem.embedding.EmbeddingClient;
 import com.hivemem.embedding.FixedEmbeddingClient;
 import com.hivemem.search.CellSearchRepository;
 import com.hivemem.search.KgSearchRepository;
+import com.hivemem.search.SearchWeightsProperties;
 import com.hivemem.tools.read.CellFieldSelection;
 import com.hivemem.tools.read.ReadToolService;
 import com.hivemem.write.AdminToolRepository;
@@ -578,6 +579,7 @@ class ProgressiveSummarizationIntegrationTest {
             WriteToolService.class,
             WriteToolRepository.class,
             ReadToolService.class,
+            SearchWeightsProperties.class,
             CellReadRepository.class,
             CellSearchRepository.class,
             KgSearchRepository.class,


### PR DESCRIPTION
## Summary

Closes #25 and #27.

- **#25 — Graph proximity as 6th search signal.** Adds `graph_proximity_scores` SQL function (V0018) that walks the `tunnels` graph from a set of anchor cells (depth ≤ 2, per-relation weights). `ranked_search` now joins the function output and includes `score_graph_proximity` in the total. Defaults: `semantic 0.30, keyword 0.15, recency 0.15, importance 0.15, popularity 0.15, graph_proximity 0.10`. Configurable via `hivemem.search.weights` and per-call via the MCP `search` tool.
- **#27 — Claude Code hook integration.** New endpoint `POST /hooks/context` accepts the `UserPromptSubmit` payload (`hook_event_name`, `prompt`, `session_id`, `cwd`), runs skip-heuristics, performs a 6-signal ranked search, applies session-scoped dedup (last 5 turns), and returns up to 3 L1 cell summaries inside a compact `<hivemem_context>` block. Internal failures collapse to empty `additionalContext` so the user prompt is never blocked. `AuthFilter` and `SessionAuthFilter` both pass `/hooks/*` through to Bearer-token auth (READER role sufficient). Audit logged as `HOOK_CALL session=… event=… promptLen=…` (no prompt content).

## Files

- New SQL: `db/migration/V0018__graph_proximity.sql`
- New Java package: `com.hivemem.hooks` (`HooksController`, `HookContextService`, `SkipHeuristics`, `SessionInjectionCache`, `ContextFormatter`, `HookProperties`, DTOs)
- `CellSearchRepository.rankedSearch` gains a 12th param + `RankedRow.scoreGraphProximity`
- `SearchWeights` + `SearchWeightsProperties` for `hivemem.search.weights`
- `AuthFilter` + `SessionAuthFilter` allow `/hooks/*`
- `examples/claude-code-hook/settings.json`
- README: 6-signal table, hook setup section

## Test plan

- [x] `./mvnw test` → 368 / 368 green (Testcontainers + pgvector pg17)
- [x] Unit tests for `SkipHeuristics`, `SessionInjectionCache`, `ContextFormatter`, `HookContextService`, `HookProperties`, `SearchWeightsProperties`
- [x] MockMvc tests for `HooksController` (200 hit, 200 empty, 200 graceful failure, 401 missing token)
- [x] End-to-end `HooksIntegrationTest` (random port, real DB, real search) — confirms `additionalContext` contains the seeded cell ID and `<hivemem_context>` tag
- [x] Audit-logging test confirms `HOOK_CALL` line emitted, no prompt body in logs
- [x] Graph-proximity SQL test (depth-1 + depth-2 chain), repository-level test, and ranked-search integration test
- [ ] Manual round-trip from a real Claude Code session against `localhost:8421/hooks/context` — to be done after deploy

## Notes

- Migration V0016 lives on an unmerged feature branch (sync protocol); this PR uses V0018, leaving the V0016/V0017 ordering as-is. Flyway tolerates the gap.
- The hook is opt-in. Default `application.yml` enables it on the server side, but Claude Code only calls it when the user adds the hook config in `~/.claude/settings.json`.