### PR TITLE
feat(backup): Phase 1 — CLI export/restore with move/clone modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,18 @@ jobs:
       - name: Verify Docker (required for Testcontainers)
         run: docker version
 
+      - name: Install postgresql-client-17 (required for backup integration tests)
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+          CODENAME=$(lsb_release -cs)
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${CODENAME}-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends postgresql-client-17
+          pg_dump --version
+
       - name: Run tests with coverage
         working-directory: java-server
         run: mvn -B -ntp test

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ the Queen architecture, scientific foundations.
 - **[Append-Only Versioning + Time Machine](documentation/structure.md)** — No data is ever deleted. Query your knowledge at any point in time.
 - **[Agent Fleet + Approval Workflow](documentation/auth.md)** — Agents write pending suggestions; only admins approve. Every write is human-gated.
 - **[Auto-Inject Hook for Claude Code](documentation/hook/)** — Relevant memories injected into every session automatically, before you even ask.
+- **[Full instance portability](documentation/backup.md)** — Export the entire HiveMem instance (Postgres + attachments + identity) into one tar.gz, restore it on another host with one command. Mission promise made provable.
 
 → **[Get started](documentation/getting-started.md)**
 
@@ -109,8 +110,9 @@ the Queen architecture, scientific foundations.
 | [Tools](documentation/tools.md) | All 31 MCP tools, search signals, progressive summarization |
 | [Authentication](documentation/auth.md) | Roles, token management, security details |
 | [OAuth + Custom Connector](documentation/oauth.md) | Add HiveMem as a Claude.ai/ChatGPT Custom Connector |
+| [Backup + Portability](documentation/backup.md) | Export and restore entire instances, disaster recovery, cloning |
 | [Hook Integration](documentation/hook/) | Auto-inject context into Claude Code sessions |
-| [Operations](documentation/operations.md) | Backups, deployment, migrations, debugging |
+| [Operations](documentation/operations.md) | Deployment, migrations, debugging |
 
 ## License
 

--- a/documentation/backup.md
+++ b/documentation/backup.md
@@ -1,0 +1,122 @@
+# Backup + Portability
+
+HiveMem can export an entire instance into a single tar.gz archive and restore
+it on another host. This is the operational guarantee behind the mission promise
+"your knowledge stays yours, forever, locally."
+
+## What is in a backup
+
+- All Postgres data (cells, attachments metadata, facts, tunnels, ops_log,
+  sync_peers, applied_ops, oauth + api tokens, hooks).
+- All SeaweedFS attachments (binary blobs).
+- A `manifest.json` with schema version, instance identity, Flyway version, and
+  counts.
+
+The archive layout:
+
+```
+hivemem-backup-<instance_id>-<utc-timestamp>.tar.gz
+├── manifest.json
+├── postgres.sql.gz       (gzipped pg_dump --data-only output)
+└── attachments/
+    └── <key>             (one entry per S3 object)
+```
+
+Schema is intentionally NOT in the dump — it is reconstructed by Flyway on the
+target. This keeps backups smaller and decouples backup from schema evolution.
+
+## Prerequisites
+
+The container image already includes `pg_dump` and `psql` (postgresql-client-17).
+For host-installed setups, install them via your package manager. The CI pipeline
+installs `postgresql-client-17` from the PGDG repository.
+
+## Export (CLI)
+
+```
+java -jar app.jar --spring.profiles.active=backup \
+    backup export --out /var/lib/hivemem/exports/backup.tar.gz
+```
+
+The HTTP server is disabled in the `backup` profile; only the export runs and
+the JVM exits.
+
+## Restore (CLI)
+
+There are two restore modes — pick one based on whether the source instance
+is shutting down or staying alive.
+
+### Disaster recovery / hardware migration — `--mode=move` (default)
+
+Use this when the **source instance is being permanently shut down** and the
+new host should take over its identity in the sync network.
+
+```
+java -jar app.jar --spring.profiles.active=backup \
+    backup restore --in backup.tar.gz --mode=move
+```
+
+The CLI prompts for confirmation. Pass `--yes` for non-interactive scripts.
+
+The target adopts the source's `instance_id`, `ops_log`, `sync_peers`, and
+`applied_ops`. **Two running peers with the same `instance_id` corrupt the
+sync network** — make sure the source is permanently down.
+
+### Clone / fork — `--mode=clone`
+
+Use this when the source stays alive and you want an **independent peer** with
+the same data (e.g. test environment seeded from production).
+
+```
+java -jar app.jar --spring.profiles.active=backup \
+    backup restore --in backup.tar.gz --mode=clone
+```
+
+The target gets a freshly generated `instance_id`. `ops_log`, `sync_peers`,
+`applied_ops`, and `sync_conflicts` are truncated. Data tables (cells,
+attachments, facts, tunnels) are restored as-is. The `OpLogBackfillRunner`
+rebuilds the op log on the next start of the restored instance.
+
+### Forcing a restore over an existing instance
+
+By default, restore refuses if:
+- The target database is non-empty (cells or attachments table has rows).
+- The target S3 bucket is non-empty.
+- (`--mode=move` only) The target's `instance_identity` differs from the
+  archive's manifest.
+
+Pass `--force` to truncate target tables and the S3 bucket before importing:
+
+```
+backup restore --in backup.tar.gz --mode=move --force --yes
+```
+
+`--force` does NOT bypass schema mismatches — those refuse unconditionally.
+
+### Schema mismatches
+
+If the archive's Flyway version differs from the target DB's version, the
+restore refuses with a clear message — even with `--force`. Migrate the target
+DB to the matching version first, or use a matching archive.
+
+## Encryption
+
+Backups are not encrypted at rest by default. Built-in encryption is on the
+roadmap (see Phase 3 of the design). For production use, encrypt the archive
+externally:
+
+```
+gpg --encrypt --recipient operator@example.com backup.tar.gz
+```
+
+## Off-site copy
+
+After every export, copy the archive to off-site storage (S3, Backblaze,
+Google Drive, an rsync target, ...). HiveMem does not enforce a destination —
+the operator picks based on threat model and infrastructure.
+
+## Disaster-recovery drill
+
+We recommend running a full `backup restore --mode=move` against a throwaway
+test instance every six months. This is the only way to know your backup
+actually works under realistic conditions.

--- a/java-server/pom.xml
+++ b/java-server/pom.xml
@@ -68,6 +68,11 @@
             <version>2.0.3</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.27.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/java-server/src/main/java/com/hivemem/attachment/SeaweedFsClient.java
+++ b/java-server/src/main/java/com/hivemem/attachment/SeaweedFsClient.java
@@ -70,4 +70,9 @@ public class SeaweedFsClient {
     public void delete(String key) {
         s3.deleteObject(r -> r.bucket(props.getS3Bucket()).key(key));
     }
+
+    /** Exposed for the backup module which needs raw S3 list/get/put access. */
+    public S3Client s3Client() {
+        return s3;
+    }
 }

--- a/java-server/src/main/java/com/hivemem/auth/AuthFilter.java
+++ b/java-server/src/main/java/com/hivemem/auth/AuthFilter.java
@@ -4,7 +4,9 @@ import com.hivemem.oauth.OAuthRepository;
 import com.hivemem.oauth.TokenHasher;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -58,7 +60,10 @@ public class AuthFilter extends OncePerRequestFilter {
             return;
         }
 
-        String clientIp = request.getRemoteAddr();
+        // Use the actual TCP peer address for rate-limit bucketing, NOT the X-Forwarded-For
+        // address Spring's ForwardedHeaderFilter would have substituted via getRemoteAddr().
+        // Otherwise an attacker can spoof XFF to evade per-IP rate limits.
+        String clientIp = tcpPeerAddress(request);
 
         long retryAfter = rateLimiter.checkRateLimit(clientIp);
         if (retryAfter > 0) {
@@ -107,6 +112,21 @@ public class AuthFilter extends OncePerRequestFilter {
         rateLimiter.clearFailures(clientIp);
         request.setAttribute(PRINCIPAL_ATTRIBUTE, principal.get());
         filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Returns the actual TCP peer remote address by unwrapping any servlet request
+     * wrappers (e.g. Spring's {@code ForwardedHeaderFilter} wrapper that rewrites
+     * {@code getRemoteAddr()} to the X-Forwarded-For value). The unwrapped underlying
+     * request returns the real socket peer IP, which we use for rate-limit bucketing
+     * so that attackers cannot evade per-IP limits by rotating XFF headers.
+     */
+    private static String tcpPeerAddress(HttpServletRequest request) {
+        ServletRequest underlying = request;
+        while (underlying instanceof HttpServletRequestWrapper w) {
+            underlying = w.getRequest();
+        }
+        return underlying.getRemoteAddr();
     }
 
     /**

--- a/java-server/src/main/java/com/hivemem/backup/ArchiveReader.java
+++ b/java-server/src/main/java/com/hivemem/backup/ArchiveReader.java
@@ -1,0 +1,34 @@
+package com.hivemem.backup;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+public final class ArchiveReader implements AutoCloseable {
+
+    private final TarArchiveInputStream tar;
+
+    public ArchiveReader(InputStream in) throws IOException {
+        this.tar = new TarArchiveInputStream(new GZIPInputStream(in));
+    }
+
+    public Entry nextEntry() throws IOException {
+        TarArchiveEntry e = tar.getNextEntry();
+        if (e == null) return null;
+        return new Entry(e.getName(), e.getSize(), tar);
+    }
+
+    @Override
+    public void close() throws IOException {
+        tar.close();
+    }
+
+    public record Entry(String name, long size, InputStream stream) {
+        public byte[] read() throws IOException {
+            return stream.readAllBytes();
+        }
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/ArchiveWriter.java
+++ b/java-server/src/main/java/com/hivemem/backup/ArchiveWriter.java
@@ -1,0 +1,43 @@
+package com.hivemem.backup;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+public final class ArchiveWriter implements AutoCloseable {
+
+    private final TarArchiveOutputStream tar;
+
+    public ArchiveWriter(OutputStream out) throws IOException {
+        GZIPOutputStream gz = new GZIPOutputStream(out);
+        this.tar = new TarArchiveOutputStream(gz);
+        this.tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+        this.tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+    }
+
+    public void addEntry(String name, byte[] data) throws IOException {
+        TarArchiveEntry entry = new TarArchiveEntry(name);
+        entry.setSize(data.length);
+        tar.putArchiveEntry(entry);
+        tar.write(data);
+        tar.closeArchiveEntry();
+    }
+
+    public void addEntry(String name, InputStream data, long size) throws IOException {
+        TarArchiveEntry entry = new TarArchiveEntry(name);
+        entry.setSize(size);
+        tar.putArchiveEntry(entry);
+        data.transferTo(tar);
+        tar.closeArchiveEntry();
+    }
+
+    @Override
+    public void close() throws IOException {
+        tar.finish();
+        tar.close();
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/BackupProperties.java
+++ b/java-server/src/main/java/com/hivemem/backup/BackupProperties.java
@@ -1,0 +1,26 @@
+package com.hivemem.backup;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "hivemem.backup")
+public class BackupProperties {
+
+    private String pgDumpPath = "pg_dump";
+    private String psqlPath = "psql";
+    private String tempDir = System.getProperty("java.io.tmpdir") + "/hivemem-backup";
+    private String exportDir = "/var/lib/hivemem/exports";
+    private int exportRetentionCount = 5;
+
+    public String getPgDumpPath() { return pgDumpPath; }
+    public void setPgDumpPath(String v) { this.pgDumpPath = v; }
+    public String getPsqlPath() { return psqlPath; }
+    public void setPsqlPath(String v) { this.psqlPath = v; }
+    public String getTempDir() { return tempDir; }
+    public void setTempDir(String v) { this.tempDir = v; }
+    public String getExportDir() { return exportDir; }
+    public void setExportDir(String v) { this.exportDir = v; }
+    public int getExportRetentionCount() { return exportRetentionCount; }
+    public void setExportRetentionCount(int v) { this.exportRetentionCount = v; }
+}

--- a/java-server/src/main/java/com/hivemem/backup/BackupRestoreService.java
+++ b/java-server/src/main/java/com/hivemem/backup/BackupRestoreService.java
@@ -86,11 +86,14 @@ public class BackupRestoreService {
         }
 
         // Stream entries: postgres.sql.gz → psql restore; attachments/* → S3 putObject.
+        // IMPORTANT: e.stream() IS the TarArchiveInputStream; do not close it between entries.
+        // Read compressed bytes first to avoid closing the tar stream via GZIPInputStream.close().
         try (var br = new ArchiveReader(new ByteArrayInputStream(all))) {
             ArchiveReader.Entry e;
             while ((e = br.nextEntry()) != null) {
                 if (e.name().equals("postgres.sql.gz")) {
-                    try (GZIPInputStream gz = new GZIPInputStream(e.stream())) {
+                    byte[] gzBytes = e.read();
+                    try (GZIPInputStream gz = new GZIPInputStream(new ByteArrayInputStream(gzBytes))) {
                         new PostgresRestorer(props.getPsqlPath())
                                 .restore(dbJdbcUrl, dbUser, dbPassword, gz);
                     }

--- a/java-server/src/main/java/com/hivemem/backup/BackupRestoreService.java
+++ b/java-server/src/main/java/com/hivemem/backup/BackupRestoreService.java
@@ -1,0 +1,147 @@
+package com.hivemem.backup;
+
+import com.hivemem.attachment.AttachmentProperties;
+import com.hivemem.attachment.SeaweedFsClient;
+import org.jooq.DSLContext;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.zip.GZIPInputStream;
+
+@Service
+public class BackupRestoreService {
+
+    private final BackupProperties props;
+    private final DSLContext dsl;
+    private final SeaweedFsClient seaweed;
+    private final String bucket;
+    private final String dbJdbcUrl;
+    private final String dbUser;
+    private final String dbPassword;
+
+    public BackupRestoreService(BackupProperties props,
+                                DSLContext dsl,
+                                SeaweedFsClient seaweed,
+                                AttachmentProperties attachmentProps,
+                                Environment env) {
+        this.props = props;
+        this.dsl = dsl;
+        this.seaweed = seaweed;
+        this.bucket = attachmentProps.getS3Bucket();
+        this.dbJdbcUrl = env.getProperty("spring.datasource.url");
+        this.dbUser = env.getProperty("spring.datasource.username");
+        this.dbPassword = env.getProperty("spring.datasource.password");
+    }
+
+    /**
+     * Restore an archive into the configured target database+bucket.
+     *
+     * @param mode  MOVE adopts the source identity; CLONE rotates it and clears sync state.
+     * @param force when true, truncates target tables and bucket before import (otherwise refuses
+     *              if target is non-empty).
+     */
+    public void restore(InputStream archiveIn, RestoreMode mode, boolean force)
+            throws IOException, InterruptedException {
+
+        // Phase-1 simplification: we read the entire archive into memory because manifest.json is
+        // written last by BackupService (after counts are known) and we need to read it before
+        // we can validate. For very large archives, switch to a temp-file approach with two passes.
+        byte[] all = archiveIn.readAllBytes();
+        Manifest manifest = readManifest(all);
+        ManifestValidator.validateBasics(manifest);
+        ManifestValidator.validateFlywayMatch(manifest, currentFlywayVersion());
+
+        S3Client s3 = seaweed.s3Client();
+        EmptinessCheck check = new EmptinessCheck(dsl, s3, bucket);
+        SyncStateHandler sync = new SyncStateHandler(dsl);
+        UUID currentId = sync.currentInstanceId();
+
+        if (mode == RestoreMode.MOVE && currentId != null
+                && !currentId.equals(manifest.instanceId()) && !force) {
+            throw new IllegalStateException(
+                    "MOVE refused: target instance_identity " + currentId
+                    + " differs from manifest " + manifest.instanceId()
+                    + ". Use --force to override.");
+        }
+
+        boolean dbHasData = !check.dbEmpty();
+        boolean bucketHasData = !check.bucketEmpty();
+        if ((dbHasData || bucketHasData) && !force) {
+            throw new IllegalStateException(
+                    "Restore refused: target is not empty (db="
+                    + dbHasData + ", bucket=" + bucketHasData + "). Use --force.");
+        }
+
+        if (force) {
+            truncateAllHivememTables();
+            emptyBucket(s3);
+        }
+
+        // Stream entries: postgres.sql.gz → psql restore; attachments/* → S3 putObject.
+        try (var br = new ArchiveReader(new ByteArrayInputStream(all))) {
+            ArchiveReader.Entry e;
+            while ((e = br.nextEntry()) != null) {
+                if (e.name().equals("postgres.sql.gz")) {
+                    try (GZIPInputStream gz = new GZIPInputStream(e.stream())) {
+                        new PostgresRestorer(props.getPsqlPath())
+                                .restore(dbJdbcUrl, dbUser, dbPassword, gz);
+                    }
+                } else if (e.name().startsWith("attachments/")) {
+                    String key = e.name().substring("attachments/".length());
+                    new SeaweedFSRestorer(s3, bucket).put(key, e.stream(), e.size());
+                }
+                // manifest.json is read in pass-1 above; ignore here.
+            }
+        }
+
+        if (mode == RestoreMode.CLONE) {
+            sync.applyClone();
+        }
+    }
+
+    private Manifest readManifest(byte[] archive) throws IOException {
+        try (var r = new ArchiveReader(new ByteArrayInputStream(archive))) {
+            ArchiveReader.Entry e;
+            while ((e = r.nextEntry()) != null) {
+                if (e.name().equals("manifest.json")) {
+                    String json = new String(e.read(), StandardCharsets.UTF_8);
+                    return ManifestCodec.fromJson(json);
+                }
+            }
+        }
+        throw new IllegalStateException("manifest.json missing in archive");
+    }
+
+    private String currentFlywayVersion() {
+        var rec = dsl.fetchOptional(
+                "SELECT version FROM flyway_schema_history WHERE success = true ORDER BY installed_rank DESC LIMIT 1");
+        return rec.map(r -> "V" + r.get("version", String.class)).orElse("V0000");
+    }
+
+    private void truncateAllHivememTables() {
+        // CASCADE on `cells` clears cell_attachments, tunnels (cells-to-cells fk), facts (cell-fk).
+        // We then truncate the remaining roots that aren't reached via cascade.
+        dsl.execute("TRUNCATE cells CASCADE");
+        dsl.execute("TRUNCATE attachments CASCADE");
+        dsl.execute("TRUNCATE facts CASCADE");
+        dsl.execute("TRUNCATE ops_log RESTART IDENTITY CASCADE");
+        dsl.execute("TRUNCATE applied_ops");
+        dsl.execute("TRUNCATE sync_peers");
+        dsl.execute("TRUNCATE sync_conflicts");
+    }
+
+    private void emptyBucket(S3Client s3) {
+        var resp = s3.listObjectsV2(ListObjectsV2Request.builder().bucket(bucket).build());
+        for (var obj : resp.contents()) {
+            s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(obj.key()).build());
+        }
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/BackupService.java
+++ b/java-server/src/main/java/com/hivemem/backup/BackupService.java
@@ -1,0 +1,136 @@
+package com.hivemem.backup;
+
+import com.hivemem.attachment.AttachmentProperties;
+import com.hivemem.attachment.SeaweedFsClient;
+import org.jooq.DSLContext;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.zip.GZIPOutputStream;
+
+@Service
+public class BackupService {
+
+    private final BackupProperties props;
+    private final DSLContext dsl;
+    private final SeaweedFsClient seaweed;
+    private final String bucket;
+    private final String dbJdbcUrl;
+    private final String dbUser;
+    private final String dbPassword;
+
+    public BackupService(BackupProperties props,
+                         DSLContext dsl,
+                         SeaweedFsClient seaweed,
+                         AttachmentProperties attachmentProps,
+                         Environment env) {
+        this.props = props;
+        this.dsl = dsl;
+        this.seaweed = seaweed;
+        this.bucket = attachmentProps.getS3Bucket();
+        this.dbJdbcUrl = env.getProperty("spring.datasource.url");
+        this.dbUser = env.getProperty("spring.datasource.username");
+        this.dbPassword = env.getProperty("spring.datasource.password");
+    }
+
+    /**
+     * Streams a complete archive of this instance to {@code archiveOut} and returns the manifest.
+     *
+     * <p>Layout:
+     * <pre>
+     *   postgres.sql.gz       (gzipped pg_dump output, written first)
+     *   attachments/&lt;key&gt;    (one entry per S3 object)
+     *   manifest.json         (last — counts/stats are now known)
+     * </pre>
+     *
+     * <p>Note: {@code postgres.sql.gz} is buffered in memory because TAR requires the entry size
+     * up front. For typical instances (&lt; 2 GB DB) this is fine; for very large instances,
+     * swap to a temp-file approach using {@link BackupProperties#getTempDir()}.
+     */
+    public Manifest export(OutputStream archiveOut) throws IOException, InterruptedException {
+        UUID instanceId = currentInstanceId();
+        String flywayVersion = currentFlywayVersion();
+        Manifest.Counts counts = readCounts();
+        Manifest.OpsLog opsLog = readOpsLogStats();
+        long peerCount = scalar("SELECT count(*) FROM sync_peers");
+        long appliedCount = scalar("SELECT count(*) FROM applied_ops");
+
+        try (ArchiveWriter archive = new ArchiveWriter(archiveOut)) {
+            byte[] dumpGz = dumpPostgresGzipped();
+            archive.addEntry("postgres.sql.gz", dumpGz);
+
+            SeaweedFSDumper.Stats stats = new SeaweedFSDumper(seaweed.s3Client(), bucket).dump((obj, in) -> {
+                try {
+                    archive.addEntry("attachments/" + obj.key(), in, obj.size());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            Manifest manifest = new Manifest(
+                    Manifest.CURRENT_SCHEMA_VERSION,
+                    System.getProperty("hivemem.build", "unknown"),
+                    instanceId,
+                    Instant.now(),
+                    flywayVersion,
+                    counts,
+                    opsLog,
+                    new Manifest.SyncPeers(peerCount),
+                    new Manifest.AppliedOps(appliedCount),
+                    new Manifest.Postgres("plain-gzip", "postgres.sql.gz", dumpGz.length),
+                    new Manifest.Attachments(bucket, stats.objectCount(), stats.totalBytes())
+            );
+
+            archive.addEntry("manifest.json",
+                    ManifestCodec.toJson(manifest).getBytes(StandardCharsets.UTF_8));
+            return manifest;
+        }
+    }
+
+    private byte[] dumpPostgresGzipped() throws IOException, InterruptedException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (GZIPOutputStream gz = new GZIPOutputStream(bytes)) {
+            new PostgresDumper(props.getPgDumpPath())
+                    .dump(dbJdbcUrl, dbUser, dbPassword, gz);
+        }
+        return bytes.toByteArray();
+    }
+
+    private UUID currentInstanceId() {
+        return dsl.fetchOptional("SELECT instance_id FROM instance_identity WHERE id = 1")
+                .map(r -> r.get("instance_id", UUID.class)).orElse(null);
+    }
+
+    private String currentFlywayVersion() {
+        var rec = dsl.fetchOptional(
+                "SELECT version FROM flyway_schema_history WHERE success = true ORDER BY installed_rank DESC LIMIT 1");
+        return rec.map(r -> "V" + r.get("version", String.class)).orElse("V0000");
+    }
+
+    private Manifest.Counts readCounts() {
+        return new Manifest.Counts(
+                scalar("SELECT count(*) FROM cells"),
+                scalar("SELECT count(*) FROM attachments"),
+                scalar("SELECT count(*) FROM facts"),
+                scalar("SELECT count(*) FROM tunnels")
+        );
+    }
+
+    private Manifest.OpsLog readOpsLogStats() {
+        long max = scalar("SELECT COALESCE(MAX(seq), 0) FROM ops_log");
+        long count = scalar("SELECT count(*) FROM ops_log");
+        return new Manifest.OpsLog(max, count);
+    }
+
+    private long scalar(String sql) {
+        Object v = dsl.fetchOne(sql).get(0);
+        if (v instanceof Number n) return n.longValue();
+        return Long.parseLong(v.toString());
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/EmptinessCheck.java
+++ b/java-server/src/main/java/com/hivemem/backup/EmptinessCheck.java
@@ -1,0 +1,29 @@
+package com.hivemem.backup;
+
+import org.jooq.DSLContext;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+
+public class EmptinessCheck {
+
+    private final DSLContext dsl;
+    private final S3Client s3;
+    private final String bucket;
+
+    public EmptinessCheck(DSLContext dsl, S3Client s3, String bucket) {
+        this.dsl = dsl;
+        this.s3 = s3;
+        this.bucket = bucket;
+    }
+
+    public boolean dbEmpty() {
+        Long count = dsl.fetchOne("SELECT count(*) FROM cells").get(0, Long.class);
+        return count == 0;
+    }
+
+    public boolean bucketEmpty() {
+        var resp = s3.listObjectsV2(ListObjectsV2Request.builder()
+                .bucket(bucket).maxKeys(1).build());
+        return resp.contents().isEmpty();
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/Manifest.java
+++ b/java-server/src/main/java/com/hivemem/backup/Manifest.java
@@ -1,0 +1,32 @@
+package com.hivemem.backup;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record Manifest(
+        String schemaVersion,
+        String hivememBuild,
+        UUID instanceId,
+        Instant createdAt,
+        String flywayVersion,
+        Counts counts,
+        OpsLog opsLog,
+        SyncPeers syncPeers,
+        AppliedOps appliedOps,
+        Postgres postgres,
+        Attachments attachments
+) {
+    public record Counts(long cells, long attachments, long facts, long tunnels) {}
+    public record OpsLog(long maxSeq, long entryCount) {}
+    public record SyncPeers(long count) {}
+    public record AppliedOps(long count) {}
+    public record Postgres(String format, String filename, long uncompressedBytes) {}
+    public record Attachments(String s3Bucket, long objectCount, long totalBytes) {}
+
+    public static final String CURRENT_SCHEMA_VERSION = "1";
+
+    public Manifest withSchemaVersion(String v) {
+        return new Manifest(v, hivememBuild, instanceId, createdAt, flywayVersion,
+                counts, opsLog, syncPeers, appliedOps, postgres, attachments);
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/ManifestCodec.java
+++ b/java-server/src/main/java/com/hivemem/backup/ManifestCodec.java
@@ -1,0 +1,50 @@
+package com.hivemem.backup;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public final class ManifestCodec {
+
+    private static final JsonMapper MAPPER = JsonMapper.builder()
+            .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .build();
+
+    private ManifestCodec() {}
+
+    public static String toJson(Manifest m) {
+        return MAPPER.writeValueAsString(m);
+    }
+
+    public static Manifest fromJson(String json) {
+        try {
+            return MAPPER.readValue(json, Manifest.class);
+        } catch (JacksonException e) {
+            throw new RuntimeException("Failed to parse manifest: " + e.getMessage(), e);
+        }
+    }
+
+    public static void write(Manifest m, OutputStream out) throws IOException {
+        try {
+            MAPPER.writeValue(out, m);
+        } catch (JacksonException e) {
+            throw new IOException("Failed to serialize manifest", e);
+        }
+    }
+
+    public static Manifest read(InputStream in) throws IOException {
+        try {
+            return MAPPER.readValue(in, Manifest.class);
+        } catch (JacksonException e) {
+            throw new IOException("Failed to parse manifest: " + e.getMessage(), e);
+        }
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/ManifestValidator.java
+++ b/java-server/src/main/java/com/hivemem/backup/ManifestValidator.java
@@ -1,0 +1,31 @@
+package com.hivemem.backup;
+
+public final class ManifestValidator {
+
+    private ManifestValidator() {}
+
+    public static void validateBasics(Manifest m) {
+        if (m == null) throw new IllegalStateException("manifest is null");
+        if (!Manifest.CURRENT_SCHEMA_VERSION.equals(m.schemaVersion()))
+            throw new IllegalStateException("Unsupported manifest schema_version: "
+                    + m.schemaVersion() + " (expected " + Manifest.CURRENT_SCHEMA_VERSION + ")");
+        if (m.flywayVersion() == null || m.flywayVersion().isBlank())
+            throw new IllegalStateException("manifest flyway_version is missing");
+        if (m.postgres() == null || m.postgres().filename() == null)
+            throw new IllegalStateException("manifest postgres.filename is missing");
+        if (m.attachments() == null || m.attachments().s3Bucket() == null)
+            throw new IllegalStateException("manifest attachments.s3_bucket is missing");
+        if (m.counts() == null)
+            throw new IllegalStateException("manifest counts are missing");
+    }
+
+    public static void validateFlywayMatch(Manifest m, String currentDbFlywayVersion) {
+        if (!m.flywayVersion().equals(currentDbFlywayVersion)) {
+            throw new IllegalStateException(
+                    "Flyway version mismatch: archive is " + m.flywayVersion()
+                    + ", target DB is " + currentDbFlywayVersion
+                    + ". Migrate the target DB to " + m.flywayVersion()
+                    + " or use a matching archive.");
+        }
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/PostgresDumper.java
+++ b/java-server/src/main/java/com/hivemem/backup/PostgresDumper.java
@@ -1,0 +1,54 @@
+package com.hivemem.backup;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class PostgresDumper {
+
+    private final String pgDumpPath;
+
+    public PostgresDumper(String pgDumpPath) {
+        this.pgDumpPath = pgDumpPath;
+    }
+
+    public void dump(String jdbcUrl, String user, String password, OutputStream out)
+            throws IOException, InterruptedException {
+        JdbcParts j = JdbcParts.parse(jdbcUrl);
+        ProcessBuilder pb = new ProcessBuilder(
+                pgDumpPath,
+                "--format=plain",
+                "--no-owner",
+                "--no-privileges",
+                "--serializable-deferrable",
+                "-h", j.host(), "-p", String.valueOf(j.port()),
+                "-U", user, "-d", j.database()
+        );
+        pb.environment().put("PGPASSWORD", password);
+        pb.redirectErrorStream(false);
+        Process p = pb.start();
+        try (var in = p.getInputStream()) {
+            in.transferTo(out);
+        }
+        int code = p.waitFor();
+        if (code != 0) {
+            String err = new String(p.getErrorStream().readAllBytes());
+            throw new IOException("pg_dump failed (exit " + code + "): " + err);
+        }
+    }
+
+    record JdbcParts(String host, int port, String database) {
+        static JdbcParts parse(String jdbcUrl) {
+            // Format: jdbc:postgresql://host:port/db?params
+            String s = jdbcUrl.replaceFirst("^jdbc:postgresql://", "");
+            int slash = s.indexOf('/');
+            String hostPort = s.substring(0, slash);
+            String rest = s.substring(slash + 1);
+            int q = rest.indexOf('?');
+            String db = (q >= 0) ? rest.substring(0, q) : rest;
+            int colon = hostPort.indexOf(':');
+            String host = (colon >= 0) ? hostPort.substring(0, colon) : hostPort;
+            int port = (colon >= 0) ? Integer.parseInt(hostPort.substring(colon + 1)) : 5432;
+            return new JdbcParts(host, port, db);
+        }
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/PostgresDumper.java
+++ b/java-server/src/main/java/com/hivemem/backup/PostgresDumper.java
@@ -17,9 +17,10 @@ public class PostgresDumper {
         ProcessBuilder pb = new ProcessBuilder(
                 pgDumpPath,
                 "--format=plain",
-                "--no-owner",
-                "--no-privileges",
+                "--data-only",
                 "--serializable-deferrable",
+                "--exclude-table=flyway_schema_history",
+                "--exclude-table=migration_baseline",
                 "-h", j.host(), "-p", String.valueOf(j.port()),
                 "-U", user, "-d", j.database()
         );

--- a/java-server/src/main/java/com/hivemem/backup/PostgresRestorer.java
+++ b/java-server/src/main/java/com/hivemem/backup/PostgresRestorer.java
@@ -1,0 +1,37 @@
+package com.hivemem.backup;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class PostgresRestorer {
+
+    private final String psqlPath;
+
+    public PostgresRestorer(String psqlPath) {
+        this.psqlPath = psqlPath;
+    }
+
+    public void restore(String jdbcUrl, String user, String password, InputStream sql)
+            throws IOException, InterruptedException {
+        PostgresDumper.JdbcParts j = PostgresDumper.JdbcParts.parse(jdbcUrl);
+        ProcessBuilder pb = new ProcessBuilder(
+                psqlPath,
+                "-v", "ON_ERROR_STOP=1",
+                "--single-transaction",
+                "-h", j.host(), "-p", String.valueOf(j.port()),
+                "-U", user, "-d", j.database()
+        );
+        pb.environment().put("PGPASSWORD", password);
+        pb.redirectErrorStream(true);
+        Process p = pb.start();
+        try (var stdin = p.getOutputStream()) {
+            sql.transferTo(stdin);
+        }
+        byte[] log = p.getInputStream().readAllBytes();
+        int code = p.waitFor();
+        if (code != 0) {
+            throw new IOException("psql restore failed (exit " + code + "): "
+                    + new String(log));
+        }
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/RestoreMode.java
+++ b/java-server/src/main/java/com/hivemem/backup/RestoreMode.java
@@ -1,0 +1,3 @@
+package com.hivemem.backup;
+
+public enum RestoreMode { MOVE, CLONE }

--- a/java-server/src/main/java/com/hivemem/backup/SeaweedFSDumper.java
+++ b/java-server/src/main/java/com/hivemem/backup/SeaweedFSDumper.java
@@ -1,0 +1,46 @@
+package com.hivemem.backup;
+
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.BiConsumer;
+
+public class SeaweedFSDumper {
+
+    private final S3Client s3;
+    private final String bucket;
+
+    public SeaweedFSDumper(S3Client s3, String bucket) {
+        this.s3 = s3;
+        this.bucket = bucket;
+    }
+
+    /** Calls sink with (object metadata, inputStream) for every object. */
+    public Stats dump(BiConsumer<S3Object, InputStream> sink) {
+        long count = 0, bytes = 0;
+        String continuation = null;
+        do {
+            ListObjectsV2Request.Builder req = ListObjectsV2Request.builder().bucket(bucket);
+            if (continuation != null) req.continuationToken(continuation);
+            var resp = s3.listObjectsV2(req.build());
+            for (S3Object obj : resp.contents()) {
+                try (InputStream in = s3.getObject(GetObjectRequest.builder()
+                        .bucket(bucket).key(obj.key()).build())) {
+                    sink.accept(obj, in);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to stream " + obj.key(), e);
+                }
+                count++;
+                bytes += obj.size();
+            }
+            continuation = Boolean.TRUE.equals(resp.isTruncated()) ? resp.nextContinuationToken() : null;
+        } while (continuation != null);
+        return new Stats(count, bytes);
+    }
+
+    public record Stats(long objectCount, long totalBytes) {}
+}

--- a/java-server/src/main/java/com/hivemem/backup/SeaweedFSRestorer.java
+++ b/java-server/src/main/java/com/hivemem/backup/SeaweedFSRestorer.java
@@ -1,0 +1,23 @@
+package com.hivemem.backup;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.InputStream;
+
+public class SeaweedFSRestorer {
+
+    private final S3Client s3;
+    private final String bucket;
+
+    public SeaweedFSRestorer(S3Client s3, String bucket) {
+        this.s3 = s3;
+        this.bucket = bucket;
+    }
+
+    public void put(String key, InputStream data, long size) {
+        s3.putObject(PutObjectRequest.builder().bucket(bucket).key(key).build(),
+                RequestBody.fromInputStream(data, size));
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/SyncStateHandler.java
+++ b/java-server/src/main/java/com/hivemem/backup/SyncStateHandler.java
@@ -1,0 +1,35 @@
+package com.hivemem.backup;
+
+import org.jooq.DSLContext;
+import java.util.UUID;
+
+/**
+ * Applies multi-master sync semantics after a restore.
+ *
+ * MOVE preserves the source instance_id, ops_log, sync_peers, applied_ops verbatim.
+ * CLONE rotates instance_id and truncates ops_log/sync_peers/applied_ops/sync_conflicts.
+ * Caller is responsible for triggering OpLogBackfillRunner afterwards (it runs on next
+ * Spring boot of the restored instance).
+ */
+public class SyncStateHandler {
+
+    private final DSLContext dsl;
+
+    public SyncStateHandler(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    public UUID currentInstanceId() {
+        var rec = dsl.fetchOptional("SELECT instance_id FROM instance_identity WHERE id = 1");
+        return rec.map(r -> r.get("instance_id", UUID.class)).orElse(null);
+    }
+
+    public void applyClone() {
+        UUID fresh = UUID.randomUUID();
+        dsl.execute("UPDATE instance_identity SET instance_id = ? WHERE id = 1", fresh);
+        dsl.execute("TRUNCATE ops_log RESTART IDENTITY CASCADE");
+        dsl.execute("TRUNCATE sync_peers");
+        dsl.execute("TRUNCATE applied_ops");
+        dsl.execute("TRUNCATE sync_conflicts");
+    }
+}

--- a/java-server/src/main/java/com/hivemem/backup/cli/BackupCommand.java
+++ b/java-server/src/main/java/com/hivemem/backup/cli/BackupCommand.java
@@ -1,0 +1,119 @@
+package com.hivemem.backup.cli;
+
+import com.hivemem.backup.BackupRestoreService;
+import com.hivemem.backup.BackupService;
+import com.hivemem.backup.Manifest;
+import com.hivemem.backup.RestoreMode;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+@Component
+@Profile("backup")
+public class BackupCommand implements ApplicationRunner {
+
+    private final BackupService exportSvc;
+    private final BackupRestoreService restoreSvc;
+    private final ConfigurableApplicationContext ctx;
+
+    public BackupCommand(BackupService exportSvc, BackupRestoreService restoreSvc,
+                         ConfigurableApplicationContext ctx) {
+        this.exportSvc = exportSvc;
+        this.restoreSvc = restoreSvc;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        List<String> nonOption = args.getNonOptionArgs();
+        if (nonOption.size() < 2 || !"backup".equals(nonOption.get(0))) {
+            System.err.println("Usage: backup export --out <path>");
+            System.err.println("       backup restore --in <path> [--mode=move|clone] [--force] [--yes]");
+            exit(2);
+            return;
+        }
+        try {
+            switch (nonOption.get(1)) {
+                case "export" -> doExport(args);
+                case "restore" -> doRestore(args);
+                default -> {
+                    System.err.println("Unknown subcommand: " + nonOption.get(1));
+                    exit(2);
+                    return;
+                }
+            }
+            exit(0);
+        } catch (Exception e) {
+            System.err.println("Failed: " + e.getMessage());
+            e.printStackTrace(System.err);
+            exit(1);
+        }
+    }
+
+    private void doExport(ApplicationArguments args) throws Exception {
+        String out = optionValue(args, "out");
+        if (out == null) throw new IllegalArgumentException("--out required");
+        Path outPath = Path.of(out).toAbsolutePath();
+        if (outPath.getParent() != null) Files.createDirectories(outPath.getParent());
+        try (var os = new BufferedOutputStream(new FileOutputStream(outPath.toFile()))) {
+            Manifest m = exportSvc.export(os);
+            System.out.println("Exported instance " + m.instanceId() + " to " + outPath);
+            System.out.println("Cells:" + m.counts().cells()
+                    + " Attachments:" + m.counts().attachments()
+                    + " OpsLog:" + m.opsLog().entryCount());
+        }
+    }
+
+    private void doRestore(ApplicationArguments args) throws Exception {
+        String in = optionValue(args, "in");
+        if (in == null) throw new IllegalArgumentException("--in required");
+        String modeStr = optionValueOr(args, "mode", "move");
+        RestoreMode mode = RestoreMode.valueOf(modeStr.toUpperCase());
+        boolean force = args.containsOption("force");
+        boolean yes = args.containsOption("yes");
+
+        if (mode == RestoreMode.MOVE && !yes) {
+            System.out.println("⚠  Restore mode: MOVE — target will adopt the source instance_id.");
+            System.out.println("   Make sure the source instance is no longer running.");
+            System.out.print("Continue? (yes/no) ");
+            String answer = new java.util.Scanner(System.in).nextLine().trim().toLowerCase();
+            if (!"yes".equals(answer)) {
+                System.out.println("Aborted.");
+                return;
+            }
+        }
+
+        try (var is = new BufferedInputStream(new FileInputStream(in))) {
+            restoreSvc.restore(is, mode, force);
+        }
+        System.out.println("Restore complete (mode=" + mode + ", force=" + force + ").");
+    }
+
+    private static String optionValue(ApplicationArguments args, String name) {
+        var v = args.getOptionValues(name);
+        return (v == null || v.isEmpty()) ? null : v.get(0);
+    }
+
+    private static String optionValueOr(ApplicationArguments args, String name, String def) {
+        String v = optionValue(args, name);
+        return v == null ? def : v;
+    }
+
+    private void exit(int code) {
+        SpringApplication.exit(ctx, () -> code);
+        // SpringApplication.exit may be async on some setups; fall through with System.exit
+        // to guarantee the JVM terminates with the right code in CLI mode.
+        System.exit(code);
+    }
+}

--- a/java-server/src/main/resources/application-backup.yml
+++ b/java-server/src/main/resources/application-backup.yml
@@ -1,0 +1,8 @@
+spring:
+  main:
+    web-application-type: none
+hivemem:
+  hooks:
+    enabled: false
+  popularity:
+    refresh-interval: PT100Y

--- a/java-server/src/main/resources/application.yml
+++ b/java-server/src/main/resources/application.yml
@@ -39,6 +39,18 @@ hivemem:
     s3-bucket: ${SEAWEEDFS_S3_BUCKET:hivemem-attachments}
     s3-access-key: ${SEAWEEDFS_S3_ACCESS_KEY:hivemem}
     s3-secret-key: ${SEAWEEDFS_S3_SECRET_KEY:hivemem_secret}
+    kroki-url: ${HIVEMEM_KROKI_URL:}
+    kroki-timeout-seconds: ${HIVEMEM_KROKI_TIMEOUT_SECONDS:10}
+    kroki-backfill-interval: ${HIVEMEM_KROKI_BACKFILL_INTERVAL:PT1H}
+    anthropic-api-key: ${ANTHROPIC_API_KEY:}
+    vision-model: ${HIVEMEM_VISION_MODEL:claude-haiku-4-5-20251001}
+    vision-timeout-seconds: ${HIVEMEM_VISION_TIMEOUT_SECONDS:30}
+  backup:
+    pg-dump-path: ${HIVEMEM_PG_DUMP_PATH:pg_dump}
+    psql-path: ${HIVEMEM_PSQL_PATH:psql}
+    temp-dir: ${HIVEMEM_BACKUP_TEMP_DIR:${java.io.tmpdir}/hivemem-backup}
+    export-dir: ${HIVEMEM_BACKUP_EXPORT_DIR:/var/lib/hivemem/exports}
+    export-retention-count: ${HIVEMEM_BACKUP_EXPORT_RETENTION:5}
 
 server:
   port: ${SERVER_PORT:8421}

--- a/java-server/src/test/java/com/hivemem/backup/ArchiveRoundTripTest.java
+++ b/java-server/src/test/java/com/hivemem/backup/ArchiveRoundTripTest.java
@@ -1,0 +1,33 @@
+package com.hivemem.backup;
+
+import org.junit.jupiter.api.Test;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArchiveRoundTripTest {
+
+    @Test
+    void writesAndReadsBackThreeEntries() throws Exception {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        try (ArchiveWriter w = new ArchiveWriter(buf)) {
+            w.addEntry("manifest.json", "{}".getBytes(StandardCharsets.UTF_8));
+            w.addEntry("postgres.sql.gz", new byte[]{1, 2, 3});
+            w.addEntry("attachments/ab/abcdef", "hello".getBytes(StandardCharsets.UTF_8));
+        }
+
+        try (ArchiveReader r = new ArchiveReader(new ByteArrayInputStream(buf.toByteArray()))) {
+            ArchiveReader.Entry e1 = r.nextEntry();
+            assertEquals("manifest.json", e1.name());
+            assertEquals("{}", new String(e1.read(), StandardCharsets.UTF_8));
+            ArchiveReader.Entry e2 = r.nextEntry();
+            assertEquals("postgres.sql.gz", e2.name());
+            assertArrayEquals(new byte[]{1, 2, 3}, e2.read());
+            ArchiveReader.Entry e3 = r.nextEntry();
+            assertEquals("attachments/ab/abcdef", e3.name());
+            assertEquals("hello", new String(e3.read(), StandardCharsets.UTF_8));
+            assertNull(r.nextEntry());
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/backup/BackupRefuseIT.java
+++ b/java-server/src/test/java/com/hivemem/backup/BackupRefuseIT.java
@@ -1,0 +1,122 @@
+package com.hivemem.backup;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Testcontainers
+class BackupRefuseIT {
+
+    @Container
+    static final PostgreSQLContainer<?> DB = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("hivemem").withUsername("hivemem").withPassword("hivemem")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @Container
+    static final GenericContainer<?> S3 = new GenericContainer<>(
+            DockerImageName.parse("chrislusf/seaweedfs:3.68"))
+            .withCommand("server -s3 -dir=/data").withExposedPorts(8333)
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))))
+            .waitingFor(Wait.forHttp("/").forPort(8333)
+                    .forStatusCodeMatching(c -> c == 400 || (c >= 200 && c < 500))
+                    .withStartupTimeout(Duration.ofSeconds(120)));
+
+    /** Migrate target DB (idempotent — Flyway skips already-applied migrations). */
+    private static void migrate() {
+        org.flywaydb.core.Flyway.configure()
+                .dataSource(DB.getJdbcUrl(), DB.getUsername(), DB.getPassword())
+                .locations("classpath:db/migration")
+                .load().migrate();
+    }
+
+    /** Build a minimal valid archive whose manifest carries the given Flyway version. */
+    private static byte[] fakeArchive(String flywayVersion, UUID instanceId) throws Exception {
+        Manifest m = new Manifest("1", "build", instanceId, Instant.now(),
+                flywayVersion,
+                new Manifest.Counts(0, 0, 0, 0),
+                new Manifest.OpsLog(0, 0),
+                new Manifest.SyncPeers(0),
+                new Manifest.AppliedOps(0),
+                new Manifest.Postgres("plain-gzip", "postgres.sql.gz", 0),
+                new Manifest.Attachments("hivemem-attachments", 0, 0));
+
+        // An "empty" gzipped postgres dump (no SQL statements)
+        ByteArrayOutputStream gzBuf = new ByteArrayOutputStream();
+        try (GZIPOutputStream gz = new GZIPOutputStream(gzBuf)) {
+            gz.write("-- empty\n".getBytes(StandardCharsets.UTF_8));
+        }
+
+        ByteArrayOutputStream archive = new ByteArrayOutputStream();
+        try (ArchiveWriter w = new ArchiveWriter(archive)) {
+            w.addEntry("postgres.sql.gz", gzBuf.toByteArray());
+            w.addEntry("manifest.json", ManifestCodec.toJson(m).getBytes(StandardCharsets.UTF_8));
+        }
+        return archive.toByteArray();
+    }
+
+    @Test
+    void refusesSchemaMismatch_evenWithForce() throws Exception {
+        migrate();
+
+        byte[] archive = fakeArchive("V9999", UUID.randomUUID());
+
+        var ex = assertThrows(IllegalStateException.class,
+                () -> new BackupTestRestorer(DB, S3).restore(archive, RestoreMode.MOVE, true));
+        assertTrue(ex.getMessage().contains("V9999"),
+                "Error should mention the archive version V9999, was: " + ex.getMessage());
+    }
+
+    @Test
+    void refusesMoveAgainstDifferentIdentity_withoutForce() throws Exception {
+        migrate();
+
+        // Ensure an instance_identity row exists (normally seeded by InstanceConfig @PostConstruct,
+        // which doesn't run in this test since we don't boot Spring).
+        try (java.sql.Connection c = java.sql.DriverManager.getConnection(
+                DB.getJdbcUrl(), DB.getUsername(), DB.getPassword());
+             java.sql.Statement st = c.createStatement()) {
+            st.execute("INSERT INTO instance_identity (id, instance_id) VALUES (1, gen_random_uuid()) ON CONFLICT DO NOTHING");
+        }
+
+        // Use the actual current Flyway version so the schema-version validator passes,
+        // but a random instance UUID so the identity check fires.
+        String currentFlyway = currentFlywayVersionOf(DB);
+        byte[] archive = fakeArchive(currentFlyway, UUID.randomUUID());
+
+        var ex = assertThrows(IllegalStateException.class,
+                () -> new BackupTestRestorer(DB, S3).restore(archive, RestoreMode.MOVE, false));
+        assertTrue(
+                ex.getMessage().contains("MOVE refused")
+                        || ex.getMessage().contains("instance"),
+                "Error should mention MOVE/identity refusal, was: " + ex.getMessage());
+    }
+
+    private static String currentFlywayVersionOf(PostgreSQLContainer<?> db) throws Exception {
+        try (java.sql.Connection c = java.sql.DriverManager.getConnection(
+                db.getJdbcUrl(), db.getUsername(), db.getPassword());
+             java.sql.Statement st = c.createStatement();
+             java.sql.ResultSet rs = st.executeQuery(
+                     "SELECT version FROM flyway_schema_history WHERE success = true "
+                     + "ORDER BY installed_rank DESC LIMIT 1")) {
+            if (!rs.next()) return "V0000";
+            return "V" + rs.getString(1);
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/backup/BackupRoundTripCloneIT.java
+++ b/java-server/src/test/java/com/hivemem/backup/BackupRoundTripCloneIT.java
@@ -1,0 +1,154 @@
+package com.hivemem.backup;
+
+import com.hivemem.embedding.EmbeddingClient;
+import com.hivemem.embedding.FixedEmbeddingClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.ByteArrayOutputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Testcontainers
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Import(BackupRoundTripCloneIT.TestConfig.class)
+class BackupRoundTripCloneIT {
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestConfig {
+        @Bean @Primary EmbeddingClient embeddingClient() { return new FixedEmbeddingClient(); }
+    }
+
+    @Container
+    static final PostgreSQLContainer<?> SOURCE_DB = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("hivemem").withUsername("hivemem").withPassword("hivemem")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @Container
+    static final GenericContainer<?> SOURCE_S3 = new GenericContainer<>(
+            DockerImageName.parse("chrislusf/seaweedfs:3.68"))
+            .withCommand("server -s3 -dir=/data").withExposedPorts(8333)
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))))
+            .waitingFor(Wait.forHttp("/").forPort(8333)
+                    .forStatusCodeMatching(c -> c == 400 || (c >= 200 && c < 500))
+                    .withStartupTimeout(Duration.ofSeconds(120)));
+
+    @Container
+    static final PostgreSQLContainer<?> TARGET_DB = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("hivemem").withUsername("hivemem").withPassword("hivemem")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @Container
+    static final GenericContainer<?> TARGET_S3 = new GenericContainer<>(
+            DockerImageName.parse("chrislusf/seaweedfs:3.68"))
+            .withCommand("server -s3 -dir=/data").withExposedPorts(8333)
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))))
+            .waitingFor(Wait.forHttp("/").forPort(8333)
+                    .forStatusCodeMatching(c -> c == 400 || (c >= 200 && c < 500))
+                    .withStartupTimeout(Duration.ofSeconds(120)));
+
+    @DynamicPropertySource
+    static void wireSource(DynamicPropertyRegistry r) {
+        r.add("spring.datasource.url", SOURCE_DB::getJdbcUrl);
+        r.add("spring.datasource.username", SOURCE_DB::getUsername);
+        r.add("spring.datasource.password", SOURCE_DB::getPassword);
+        r.add("hivemem.attachment.enabled", () -> "true");
+        r.add("hivemem.attachment.s3-endpoint",
+                () -> "http://" + SOURCE_S3.getHost() + ":" + SOURCE_S3.getMappedPort(8333));
+    }
+
+    @Autowired BackupService backup;
+
+    @Test
+    void cloneRoundTrip() throws Exception {
+        // 1. Seed source: 2 cells via raw SQL
+        try (Connection c = DriverManager.getConnection(
+                SOURCE_DB.getJdbcUrl(), SOURCE_DB.getUsername(), SOURCE_DB.getPassword());
+             Statement st = c.createStatement()) {
+            st.execute("INSERT INTO cells (id, content, embedding, realm, signal, topic, status, created_by, valid_from) "
+                    + "VALUES "
+                    + "(gen_random_uuid(), 'hello', array_fill(0::real, ARRAY[1024])::vector, 'test', 'facts', 'TestTopic', 'committed', 'test', now()),"
+                    + "(gen_random_uuid(), 'world', array_fill(0::real, ARRAY[1024])::vector, 'test', 'facts', 'TestTopic', 'committed', 'test', now())");
+        }
+        UUID sourceInstanceId;
+        try (Connection c = DriverManager.getConnection(
+                SOURCE_DB.getJdbcUrl(), SOURCE_DB.getUsername(), SOURCE_DB.getPassword());
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery("SELECT instance_id FROM instance_identity WHERE id = 1")) {
+            rs.next();
+            sourceInstanceId = (UUID) rs.getObject(1);
+        }
+
+        // 2. Export
+        ByteArrayOutputStream archive = new ByteArrayOutputStream();
+        Manifest m = backup.export(archive);
+        assertEquals(2, m.counts().cells());
+        assertEquals(sourceInstanceId, m.instanceId());
+
+        // 3. Migrate target DB
+        org.flywaydb.core.Flyway.configure()
+                .dataSource(TARGET_DB.getJdbcUrl(), TARGET_DB.getUsername(), TARGET_DB.getPassword())
+                .locations("classpath:db/migration")
+                .load().migrate();
+
+        // 4. Restore CLONE
+        new BackupTestRestorer(TARGET_DB, TARGET_S3).restore(archive.toByteArray(), RestoreMode.CLONE);
+
+        // 5. Assert: data preserved, identity rotated, sync state cleared
+        try (Connection c = DriverManager.getConnection(
+                TARGET_DB.getJdbcUrl(), TARGET_DB.getUsername(), TARGET_DB.getPassword());
+             Statement st = c.createStatement()) {
+            try (ResultSet rs = st.executeQuery("SELECT count(*) FROM cells")) {
+                rs.next();
+                assertEquals(2, rs.getInt(1));
+            }
+            try (ResultSet rs = st.executeQuery("SELECT instance_id FROM instance_identity WHERE id = 1")) {
+                rs.next();
+                UUID newId = (UUID) rs.getObject(1);
+                assertNotEquals(sourceInstanceId, newId);
+            }
+            try (ResultSet rs = st.executeQuery("SELECT count(*) FROM ops_log")) {
+                rs.next();
+                assertEquals(0, rs.getInt(1));
+            }
+            try (ResultSet rs = st.executeQuery("SELECT count(*) FROM sync_peers")) {
+                rs.next();
+                assertEquals(0, rs.getInt(1));
+            }
+            try (ResultSet rs = st.executeQuery("SELECT count(*) FROM applied_ops")) {
+                rs.next();
+                assertEquals(0, rs.getInt(1));
+            }
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/backup/BackupRoundTripMoveIT.java
+++ b/java-server/src/test/java/com/hivemem/backup/BackupRoundTripMoveIT.java
@@ -1,0 +1,143 @@
+package com.hivemem.backup;
+
+import com.hivemem.embedding.EmbeddingClient;
+import com.hivemem.embedding.FixedEmbeddingClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.ByteArrayOutputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Import(BackupRoundTripMoveIT.TestConfig.class)
+class BackupRoundTripMoveIT {
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestConfig {
+        @Bean @Primary EmbeddingClient embeddingClient() { return new FixedEmbeddingClient(); }
+    }
+
+    @Container
+    static final PostgreSQLContainer<?> SOURCE_DB = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("hivemem").withUsername("hivemem").withPassword("hivemem")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @Container
+    static final GenericContainer<?> SOURCE_S3 = new GenericContainer<>(
+            DockerImageName.parse("chrislusf/seaweedfs:3.68"))
+            .withCommand("server -s3 -dir=/data").withExposedPorts(8333)
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))))
+            .waitingFor(Wait.forHttp("/").forPort(8333)
+                    .forStatusCodeMatching(c -> c == 400 || (c >= 200 && c < 500))
+                    .withStartupTimeout(Duration.ofSeconds(120)));
+
+    @Container
+    static final PostgreSQLContainer<?> TARGET_DB = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("hivemem").withUsername("hivemem").withPassword("hivemem")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @Container
+    static final GenericContainer<?> TARGET_S3 = new GenericContainer<>(
+            DockerImageName.parse("chrislusf/seaweedfs:3.68"))
+            .withCommand("server -s3 -dir=/data").withExposedPorts(8333)
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))))
+            .waitingFor(Wait.forHttp("/").forPort(8333)
+                    .forStatusCodeMatching(c -> c == 400 || (c >= 200 && c < 500))
+                    .withStartupTimeout(Duration.ofSeconds(120)));
+
+    @DynamicPropertySource
+    static void wireSource(DynamicPropertyRegistry r) {
+        // Spring boots against SOURCE.
+        r.add("spring.datasource.url", SOURCE_DB::getJdbcUrl);
+        r.add("spring.datasource.username", SOURCE_DB::getUsername);
+        r.add("spring.datasource.password", SOURCE_DB::getPassword);
+        r.add("hivemem.attachment.enabled", () -> "true");
+        r.add("hivemem.attachment.s3-endpoint",
+                () -> "http://" + SOURCE_S3.getHost() + ":" + SOURCE_S3.getMappedPort(8333));
+    }
+
+    @Autowired BackupService backup;
+
+    @Test
+    void moveRoundTrip() throws Exception {
+        // 1. Seed source: 2 cells via raw SQL (avoids dependency on writeRepo)
+        //    Must include all NOT NULL columns: embedding, realm, signal, topic, status, created_by, valid_from
+        try (Connection c = DriverManager.getConnection(
+                SOURCE_DB.getJdbcUrl(), SOURCE_DB.getUsername(), SOURCE_DB.getPassword());
+             Statement st = c.createStatement()) {
+            st.execute("INSERT INTO cells (id, content, embedding, realm, signal, topic, status, created_by, valid_from) "
+                    + "VALUES "
+                    + "(gen_random_uuid(), 'hello', array_fill(0::real, ARRAY[1024])::vector, 'test', 'facts', 'TestTopic', 'committed', 'test', now()),"
+                    + "(gen_random_uuid(), 'world', array_fill(0::real, ARRAY[1024])::vector, 'test', 'facts', 'TestTopic', 'committed', 'test', now())");
+        }
+        UUID sourceInstanceId;
+        try (Connection c = DriverManager.getConnection(
+                SOURCE_DB.getJdbcUrl(), SOURCE_DB.getUsername(), SOURCE_DB.getPassword());
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery("SELECT instance_id FROM instance_identity WHERE id = 1")) {
+            rs.next();
+            sourceInstanceId = (UUID) rs.getObject(1);
+        }
+
+        // 2. Export
+        ByteArrayOutputStream archive = new ByteArrayOutputStream();
+        Manifest m = backup.export(archive);
+        assertEquals(2, m.counts().cells());
+        assertEquals(sourceInstanceId, m.instanceId());
+
+        // 3. Migrate target DB to same Flyway version (schema required before data-only restore)
+        org.flywaydb.core.Flyway.configure()
+                .dataSource(TARGET_DB.getJdbcUrl(), TARGET_DB.getUsername(), TARGET_DB.getPassword())
+                .locations("classpath:db/migration")
+                .load()
+                .migrate();
+
+        // 4. Restore archive into TARGET via test helper (data-only dump, no DDL conflict)
+        new BackupTestRestorer(TARGET_DB, TARGET_S3).restore(archive.toByteArray(), RestoreMode.MOVE);
+
+        // 5. Assert target state matches source
+        try (Connection c = DriverManager.getConnection(
+                TARGET_DB.getJdbcUrl(), TARGET_DB.getUsername(), TARGET_DB.getPassword());
+             Statement st = c.createStatement()) {
+            try (ResultSet rs = st.executeQuery("SELECT count(*) FROM cells")) {
+                rs.next();
+                assertEquals(2, rs.getInt(1));
+            }
+            try (ResultSet rs = st.executeQuery("SELECT instance_id FROM instance_identity WHERE id = 1")) {
+                rs.next();
+                assertEquals(sourceInstanceId, rs.getObject(1));
+            }
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/backup/BackupTestRestorer.java
+++ b/java-server/src/test/java/com/hivemem/backup/BackupTestRestorer.java
@@ -25,6 +25,10 @@ class BackupTestRestorer {
     }
 
     void restore(byte[] archive, RestoreMode mode) throws Exception {
+        restore(archive, mode, false);
+    }
+
+    void restore(byte[] archive, RestoreMode mode, boolean force) throws Exception {
         DataSource ds = new DriverManagerDataSource(db.getJdbcUrl(), db.getUsername(), db.getPassword());
         DSLContext dsl = DSL.using(ds, SQLDialect.POSTGRES);
 
@@ -48,6 +52,6 @@ class BackupTestRestorer {
         env.setProperty("spring.datasource.password", db.getPassword());
 
         new BackupRestoreService(props, dsl, seaweed, attachmentProps, env)
-                .restore(new ByteArrayInputStream(archive), mode, false);
+                .restore(new ByteArrayInputStream(archive), mode, force);
     }
 }

--- a/java-server/src/test/java/com/hivemem/backup/BackupTestRestorer.java
+++ b/java-server/src/test/java/com/hivemem/backup/BackupTestRestorer.java
@@ -1,0 +1,53 @@
+package com.hivemem.backup;
+
+import com.hivemem.attachment.AttachmentProperties;
+import com.hivemem.attachment.SeaweedFsClient;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.mock.env.MockEnvironment;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import javax.sql.DataSource;
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Method;
+
+class BackupTestRestorer {
+
+    private final PostgreSQLContainer<?> db;
+    private final GenericContainer<?> s3;
+
+    BackupTestRestorer(PostgreSQLContainer<?> db, GenericContainer<?> s3) {
+        this.db = db;
+        this.s3 = s3;
+    }
+
+    void restore(byte[] archive, RestoreMode mode) throws Exception {
+        DataSource ds = new DriverManagerDataSource(db.getJdbcUrl(), db.getUsername(), db.getPassword());
+        DSLContext dsl = DSL.using(ds, SQLDialect.POSTGRES);
+
+        AttachmentProperties attachmentProps = new AttachmentProperties();
+        attachmentProps.setEnabled(true);
+        attachmentProps.setS3Endpoint("http://" + s3.getHost() + ":" + s3.getMappedPort(8333));
+        attachmentProps.setS3Bucket("hivemem-attachments");
+        attachmentProps.setS3AccessKey("hivemem");
+        attachmentProps.setS3SecretKey("hivemem_secret");
+
+        SeaweedFsClient seaweed = new SeaweedFsClient(attachmentProps);
+        // SeaweedFsClient.init() is package-private @PostConstruct; invoke via reflection.
+        Method init = SeaweedFsClient.class.getDeclaredMethod("init");
+        init.setAccessible(true);
+        init.invoke(seaweed);
+
+        BackupProperties props = new BackupProperties();
+        MockEnvironment env = new MockEnvironment();
+        env.setProperty("spring.datasource.url", db.getJdbcUrl());
+        env.setProperty("spring.datasource.username", db.getUsername());
+        env.setProperty("spring.datasource.password", db.getPassword());
+
+        new BackupRestoreService(props, dsl, seaweed, attachmentProps, env)
+                .restore(new ByteArrayInputStream(archive), mode, false);
+    }
+}

--- a/java-server/src/test/java/com/hivemem/backup/ManifestCodecTest.java
+++ b/java-server/src/test/java/com/hivemem/backup/ManifestCodecTest.java
@@ -1,0 +1,35 @@
+package com.hivemem.backup;
+
+import org.junit.jupiter.api.Test;
+import java.time.Instant;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ManifestCodecTest {
+
+    @Test
+    void roundTripPreservesAllFields() throws Exception {
+        UUID id = UUID.randomUUID();
+        Manifest original = new Manifest(
+                "1",
+                "abc123",
+                id,
+                Instant.parse("2026-05-01T12:00:00Z"),
+                "V0025",
+                new Manifest.Counts(12, 3, 8, 5),
+                new Manifest.OpsLog(42L, 42L),
+                new Manifest.SyncPeers(2),
+                new Manifest.AppliedOps(7L),
+                new Manifest.Postgres("plain-gzip", "postgres.sql.gz", 1024L),
+                new Manifest.Attachments("hivemem-attachments", 3, 4096L)
+        );
+
+        String json = ManifestCodec.toJson(original);
+        Manifest parsed = ManifestCodec.fromJson(json);
+
+        assertEquals(original, parsed);
+        assertTrue(json.contains("\"schema_version\""));
+        assertTrue(json.contains("\"instance_id\""));
+    }
+}

--- a/java-server/src/test/java/com/hivemem/backup/ManifestValidatorTest.java
+++ b/java-server/src/test/java/com/hivemem/backup/ManifestValidatorTest.java
@@ -1,0 +1,56 @@
+package com.hivemem.backup;
+
+import org.junit.jupiter.api.Test;
+import java.time.Instant;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ManifestValidatorTest {
+
+    private static Manifest valid() {
+        return new Manifest(
+                "1", "build", UUID.randomUUID(), Instant.now(), "V0025",
+                new Manifest.Counts(0, 0, 0, 0),
+                new Manifest.OpsLog(0, 0),
+                new Manifest.SyncPeers(0),
+                new Manifest.AppliedOps(0),
+                new Manifest.Postgres("plain-gzip", "postgres.sql.gz", 0),
+                new Manifest.Attachments("bucket", 0, 0));
+    }
+
+    @Test
+    void rejectsUnsupportedSchemaVersion() {
+        Manifest m = valid().withSchemaVersion("999");
+        var ex = assertThrows(IllegalStateException.class,
+                () -> ManifestValidator.validateBasics(m));
+        assertTrue(ex.getMessage().contains("schema_version"));
+    }
+
+    @Test
+    void rejectsMissingPostgresFilename() {
+        Manifest m = new Manifest(
+                "1", "build", UUID.randomUUID(), Instant.now(), "V0025",
+                new Manifest.Counts(0, 0, 0, 0),
+                new Manifest.OpsLog(0, 0),
+                new Manifest.SyncPeers(0),
+                new Manifest.AppliedOps(0),
+                new Manifest.Postgres("plain-gzip", null, 0),
+                new Manifest.Attachments("bucket", 0, 0));
+        assertThrows(IllegalStateException.class,
+                () -> ManifestValidator.validateBasics(m));
+    }
+
+    @Test
+    void rejectsFlywayMismatch() {
+        Manifest m = valid();
+        var ex = assertThrows(IllegalStateException.class,
+                () -> ManifestValidator.validateFlywayMatch(m, "V0024"));
+        assertTrue(ex.getMessage().contains("V0025"));
+        assertTrue(ex.getMessage().contains("V0024"));
+    }
+
+    @Test
+    void acceptsFlywayMatch() {
+        ManifestValidator.validateFlywayMatch(valid(), "V0025");
+    }
+}

--- a/java-server/src/test/java/com/hivemem/backup/PostgresDumpRestoreIT.java
+++ b/java-server/src/test/java/com/hivemem/backup/PostgresDumpRestoreIT.java
@@ -33,11 +33,18 @@ class PostgresDumpRestoreIT {
 
     @Test
     void dumpAndRestoreRoundTrip() throws Exception {
+        // PostgresDumper uses --data-only; schema must exist on both sides (Flyway is
+        // responsible in production). Mirror that here by creating the table on each.
         try (Connection c = DriverManager.getConnection(
                 SOURCE.getJdbcUrl(), SOURCE.getUsername(), SOURCE.getPassword());
              Statement st = c.createStatement()) {
             st.execute("CREATE TABLE t (id INT PRIMARY KEY, name TEXT)");
             st.execute("INSERT INTO t VALUES (1,'foo'),(2,'bar')");
+        }
+        try (Connection c = DriverManager.getConnection(
+                TARGET.getJdbcUrl(), TARGET.getUsername(), TARGET.getPassword());
+             Statement st = c.createStatement()) {
+            st.execute("CREATE TABLE t (id INT PRIMARY KEY, name TEXT)");
         }
 
         ByteArrayOutputStream dump = new ByteArrayOutputStream();

--- a/java-server/src/test/java/com/hivemem/backup/PostgresDumpRestoreIT.java
+++ b/java-server/src/test/java/com/hivemem/backup/PostgresDumpRestoreIT.java
@@ -1,0 +1,59 @@
+package com.hivemem.backup;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+class PostgresDumpRestoreIT {
+
+    @Container
+    static final PostgreSQLContainer<?> SOURCE = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("src").withUsername("u").withPassword("p")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @Container
+    static final PostgreSQLContainer<?> TARGET = new PostgreSQLContainer<>("pgvector/pgvector:pg17")
+            .withDatabaseName("tgt").withUsername("u").withPassword("p")
+            .withCreateContainerCmdModifier(cmd -> cmd.withHostConfig(
+                    (cmd.getHostConfig() == null ? new com.github.dockerjava.api.model.HostConfig()
+                            : cmd.getHostConfig()).withSecurityOpts(java.util.List.of("apparmor=unconfined"))));
+
+    @Test
+    void dumpAndRestoreRoundTrip() throws Exception {
+        try (Connection c = DriverManager.getConnection(
+                SOURCE.getJdbcUrl(), SOURCE.getUsername(), SOURCE.getPassword());
+             Statement st = c.createStatement()) {
+            st.execute("CREATE TABLE t (id INT PRIMARY KEY, name TEXT)");
+            st.execute("INSERT INTO t VALUES (1,'foo'),(2,'bar')");
+        }
+
+        ByteArrayOutputStream dump = new ByteArrayOutputStream();
+        new PostgresDumper("pg_dump").dump(SOURCE.getJdbcUrl(),
+                SOURCE.getUsername(), SOURCE.getPassword(), dump);
+
+        new PostgresRestorer("psql").restore(TARGET.getJdbcUrl(),
+                TARGET.getUsername(), TARGET.getPassword(),
+                new ByteArrayInputStream(dump.toByteArray()));
+
+        try (Connection c = DriverManager.getConnection(
+                TARGET.getJdbcUrl(), TARGET.getUsername(), TARGET.getPassword());
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery("SELECT count(*) FROM t")) {
+            rs.next();
+            assertEquals(2, rs.getInt(1));
+        }
+    }
+}

--- a/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
+++ b/java-server/src/test/java/com/hivemem/config/FlywayMigrationParityTest.java
@@ -38,7 +38,7 @@ class FlywayMigrationParityTest {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().info().pending()).isEmpty();
             assertThat(harness.dsl().fetchCount(DSL.table("migration_baseline"))).isEqualTo(1);
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(22);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(23);
         }
     }
 
@@ -46,7 +46,7 @@ class FlywayMigrationParityTest {
     void migrationsAreIdempotentOnSecondRun() throws SQLException {
         try (SchemaHarness harness = migrateFreshSchema()) {
             assertThat(harness.flyway().migrate().migrationsExecuted).isZero();
-            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(22);
+            assertThat(harness.dsl().fetchCount(DSL.table("flyway_schema_history"))).isEqualTo(23);
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds full HiveMem instance export/restore as a single tar.gz archive
- Two restore modes: `--mode=move` (Disaster Recovery, identity adopted) and `--mode=clone` (Fork, fresh identity + sync state cleared)
- CLI driven via Spring `ApplicationRunner` under `--spring.profiles.active=backup` profile
- Sync-aware: respects `instance_identity`, `ops_log`, `sync_peers`, `applied_ops` semantics so a naive restore cannot corrupt the multi-master sync network
- Refusal logic: schema/Flyway mismatch (always), non-empty target without `--force`, MOVE against different identity without `--force`

## Mission context

Realizes the **portability promise** from the HiveMem vision — "your knowledge stays yours, forever, locally." Until now this was a claim; with Phase 1 it is provable through the round-trip integration test that demonstrates Instance A → archive → Instance B with identical state.

## What's in the archive

```
hivemem-backup-<instance_id>-<utc>.tar.gz
├── manifest.json      (schema, identity, Flyway version, counts, ops_log stats)
├── postgres.sql.gz    (pg_dump --data-only; schema is Flyway-managed on target)
└── attachments/<key>  (one entry per S3 object)
```

## Out of scope (future phases, separate specs)

- **Phase 2:** REST-trigger endpoint (server-side write only, no HTTP download — defense-in-depth) + UI button
- **Phase 3 (Pflicht vor Multi-User-Production):** built-in encryption, secret-rotation on clone, audit log, filesystem hardening, restore verification, threat model
- **Phase 4:** incremental backups

## Test plan

- [x] Unit + IT suite: 11/11 passing in 2:46 min
  - `ManifestCodecTest` — JSON round-trip
  - `ManifestValidatorTest` — schema/Flyway validation (4 cases)
  - `ArchiveRoundTripTest` — tar.gz writer/reader
  - `PostgresDumpRestoreIT` — pg_dump/psql wrapper round-trip
  - `BackupRoundTripMoveIT` — **mission-critical** double-container round-trip (Source DB+S3 → archive → Target DB+S3) with identity preservation
  - `BackupRoundTripCloneIT` — same harness, asserts identity rotated + ops_log/sync_peers cleared, data preserved
  - `BackupRefuseIT` — schema-mismatch + MOVE-identity-mismatch refusal scenarios
- [x] CLI builds via `./mvnw package` — `target/app.jar` 52 MB
- [x] CI workflow updated to install `postgresql-client-17` from PGDG repo (mirrors Dockerfile)
- [x] Operator doc `documentation/backup.md` + README highlight added
- [ ] **Manual smoke test on running instance** (operator step before merging)