### PR TITLE
ci: harden the pipeline after the Dependabot sweep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,33 @@
 version: 2
 updates:
+  # One combined PR per ecosystem per week. Ungrouped, a batch of bumps that
+  # touch the same workflow file serialises behind branch protection and can
+  # leave later PRs with conflicts Dependabot cannot rebase away.
   - package-ecosystem: "maven"
     directory: "/java-server"
     schedule:
       interval: "weekly"
+    groups:
+      maven-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      docker-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel a superseded run of the same ref instead of letting it race the new
+# one to completion. `mvn verify`, Playwright and the image build are all
+# expensive, so a rebase or follow-up push would otherwise burn a full extra
+# run alongside the new one. Gated to pull_request only so a push to main is
+# never cancelled mid-run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -134,5 +143,14 @@ jobs:
           context: .
           file: Dockerfile
           push: false
+          # cache-from only: GHA cache reads flow down (a PR branch reads the
+          # cache written on main), but writes are scoped to the writing ref.
+          # An export from this PR job would be unusable by docker.yml on
+          # main and by every other PR, yet would still consume the single
+          # repo-wide 10 GB LRU quota. mode=max exports every layer of every
+          # stage (node UI build, full Maven tree, JDK base, apt/tesseract/
+          # postgresql-client runtime layers) — multiple GB per PR ref, and
+          # enough PR refs evict main's entry, sending the publish build on
+          # the critical path to prod cold. This job only needs to be
+          # cache-warm, which cache-from alone provides.
           cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The root Dockerfile is the single source of truth for the Node major
+      # version. Reading it here means a Dependabot bump of the FROM line moves
+      # CI too, so the image and its test can never be built on different lines.
+      - name: Read Node version from Dockerfile
+        id: node
+        working-directory: ${{ github.workspace }}
+        run: |
+          version=$(grep -m1 -oP '^FROM node:\K[0-9]+' Dockerfile || true)
+          if [ -z "$version" ]; then
+            echo "::error::Could not read a Node major version from the FROM line in Dockerfile"
+            exit 1
+          fi
+          echo "Node major version from Dockerfile: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          # Must match the ui-build stage in the root Dockerfile — that image is
-          # never built on a PR, so this job is the only test of the Node line.
-          node-version: "24"
+          node-version: ${{ steps.node.outputs.version }}
           cache: npm
           cache-dependency-path: knowledge-ui/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,25 @@ jobs:
           path: knowledge-ui/playwright-report/
           retention-days: 7
           if-no-files-found: ignore
+
+  # Builds the shipped image on pull requests without publishing it. docker.yml
+  # only runs on push to main and on tags, so without this job a change to the
+  # Dockerfile would first be built *after* it was merged.
+  image:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-# Pinned to the toolchain versions CI tests against (Node 24 LTS, JDK 26) — keep
-# in sync with .github/workflows/ci.yml when bumping. Node stays on the LTS line;
-# the Current line (25) ships to prod untested because no PR job builds this file.
+# Single source of truth for the Node major version: the frontend job in
+# .github/workflows/ci.yml reads it off the FROM line below, so a Dependabot bump
+# here moves CI with it. Stay on the LTS line (24) — Current (25) builds fine but
+# is not what a prod image should ride on. JDK is 26, matching ci.yml.
 FROM node:24-alpine AS ui-build
 
 WORKDIR /ui


### PR DESCRIPTION
Three CI changes, plus the fixes the whole-branch review asked for.

- **`ci.yml` builds the root Dockerfile on pull requests** (`push: false`). Until now `docker.yml` only ran on push to main and on tags, so a Dockerfile change was first built *after* it was merged.
- **The `frontend` job reads the Node major version off the Dockerfile's FROM line** instead of pinning it a second time, so the image and its test cannot be built on different Node lines. The step fails with an `::error::` annotation if the FROM line is ever written in a shape it cannot parse.
- **`dependabot.yml` groups updates into one PR per ecosystem** (maven/docker majors still arrive individually). Four action bumps last week each edited `cli.yml`, serialised behind branch protection, and the last one hit a conflict Dependabot could not rebase away.
- The `image` job uses `cache-from` only — a PR job's cache export is scoped to its own ref, unusable by the publish build, and would evict it from the repo-wide 10 GB LRU. A `concurrency:` group cancels superseded PR runs (never pushes to main).

This PR is itself the test of the first point: the `image` check below is the new job running for the first time.

**Known limitation:** `required_status_checks` on `main` is `["test"]`, so `image` and `frontend` are advisory — a broken Dockerfile is made visible, not blocked. Changing that is a branch-protection decision, deliberately left for later.